### PR TITLE
17 basic theme footer

### DIFF
--- a/psulib_base.info.yml
+++ b/psulib_base.info.yml
@@ -18,4 +18,6 @@ regions:
   content: Main content
   sidebar_first: Sidebar first
   sidebar_second: Sidebar second
-  footer: Footer
+  footer_left: Footer Left
+  footer: Footer Main
+  footer_bottom: Footer Bottom

--- a/psulib_base.theme
+++ b/psulib_base.theme
@@ -20,6 +20,9 @@ function psulib_base_preprocess_page(array &$page) {
   $sidebar_second_content = \Drupal::service('renderer')->render($page['page']['sidebar_second']);
   $sidebar_second_real_content = preg_replace('/<!--(.*)-->/Uis', '', trim($sidebar_second_content));
   $page['has_sidebar_second'] = (bool) strlen(trim($sidebar_second_real_content));
+
+  // Add logo and site for footer.
+  $page['site_logo'] = base_path() . \Drupal::theme()->getActiveTheme()->getLogo();
 }
 
 /**

--- a/scss/base/_footer.scss
+++ b/scss/base/_footer.scss
@@ -11,18 +11,57 @@ footer {
     flex-direction: column;
   }
 
-  .navbar-nav {
+  .site-logo img {
+    height: 52px;
+  }
 
-    .nav-link {
-      color: $pa-link-light;
+  .nav-link,
+  a {
+    color: $pa-slate-light;
+    padding-left: 0;
+    line-height: calc(var(--bs-body-line-height) * .75);
 
-      &:hover {
-          color: $pa-link-light;
+    &:hover {
+        color: $pa-slate-light;
+    }
+
+    &:active {
+        color: $lions-roar-light;
+    }
+  }
+
+  .list-inline {
+
+    .list-inline-item {
+      &:after {
+        padding-left: $list-inline-padding;
+        content: "|"
       }
 
-      &:active {
-          color: $lions-roar-light;
+      &:last-child:after {
+        content: none;
+        padding-left: 0;
       }
+
+    }
+  }
+
+  .block-social-media-links {
+
+    a {
+      color: $pa-sky-light;
+    }
+
+    a:hover {
+      color: $pa-sky-max-light;
+    }
+  }
+
+  .menu--footer .row {
+    // Removing extra margin from last 2 footer menu sections.
+    .col:nth-last-child(2),
+    .col:last-child {
+      margin-bottom: 0 !important;
     }
   }
 }

--- a/scss/base/_layout.scss
+++ b/scss/base/_layout.scss
@@ -1,11 +1,3 @@
-
-.region-sidebar-first,
-.region-sidebar-second,
-.region-footer,
-.region-content {
-  padding: $region-padding;
-}
-
 .node-preview-container {
   background-color: $white;
   .node-preview-backlink {
@@ -18,8 +10,22 @@
   }
 }
 
-
 .region-nav-branding,
 .region-nav-additional {
   flex-shrink: 0;
+}
+
+// Add a max width the container-fluid and increasing padding on larger
+// displays.
+.container-fluid {
+  max-width: calc(map-get($container-max-widths, xxl) + 3rem);
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+
+  @include media-breakpoint-up(md) {
+    max-width: calc(map-get($container-max-widths, xxl) + 6rem);
+
+    padding-left: 3rem;
+    padding-right: 3rem;
+  }
 }

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -5,44 +5,44 @@
 @import 'variables_bootstrap';
 
 // 1. Include functions first (so you can manipulate colors, SVGs, calc, etc)
-@import "bootstrap/scss/functions";
+@import "~bootstrap/scss/functions";
 
 // 2. Include any default variable overrides here
 @import 'colors';
 
 // 3. Include remainder of required Bootstrap stylesheets (including any separate color mode stylesheets)
-@import "bootstrap/scss/variables";
-@import "bootstrap/scss/variables-dark";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/variables-dark";
 
 // 4. Include any default map overrides here
 
 // 5. Include remainder of required parts
-@import "bootstrap/scss/maps";
-@import "bootstrap/scss/mixins";
-@import "bootstrap/scss/root";
+@import "~bootstrap/scss/maps";
+@import "~bootstrap/scss/mixins";
+@import "~bootstrap/scss/root";
 
 // 6. Optionally include any other parts as needed
-@import "bootstrap/scss/utilities";
-@import "bootstrap/scss/reboot";
-@import "bootstrap/scss/type";
-@import "bootstrap/scss/images";
-@import "bootstrap/scss/containers";
-@import "bootstrap/scss/grid";
-@import "bootstrap/scss/tables";
-@import "bootstrap/scss/forms";
-@import "bootstrap/scss/buttons";
-@import "bootstrap/scss/dropdown";
-@import "bootstrap/scss/transitions";
-@import "bootstrap/scss/badge";
-@import "bootstrap/scss/list-group";
-@import "bootstrap/scss/breadcrumb";
-@import "bootstrap/scss/close";
-@import "bootstrap/scss/nav";
-@import "bootstrap/scss/navbar";
-@import "bootstrap/scss/helpers";
+@import "~bootstrap/scss/utilities";
+@import "~bootstrap/scss/reboot";
+@import "~bootstrap/scss/type";
+@import "~bootstrap/scss/images";
+@import "~bootstrap/scss/containers";
+@import "~bootstrap/scss/grid";
+@import "~bootstrap/scss/tables";
+@import "~bootstrap/scss/forms";
+@import "~bootstrap/scss/buttons";
+@import "~bootstrap/scss/dropdown";
+@import "~bootstrap/scss/transitions";
+@import "~bootstrap/scss/badge";
+@import "~bootstrap/scss/list-group";
+@import "~bootstrap/scss/breadcrumb";
+@import "~bootstrap/scss/close";
+@import "~bootstrap/scss/nav";
+@import "~bootstrap/scss/navbar";
+@import "~bootstrap/scss/helpers";
 
 // 7. Optionally include utilities API last to generate classes based on the Sass map in `_utilities.scss`
-@import "bootstrap/scss/utilities/api";
+@import "~bootstrap/scss/utilities/api";
 
 @import 'mixins';
 @import 'base';

--- a/templates/block/social-media-links-platforms.html.twig
+++ b/templates/block/social-media-links-platforms.html.twig
@@ -1,0 +1,35 @@
+{#
+/**
+ * @ingroup themeable
+ */
+#}
+
+{%
+    set classes = [
+        'social-media-links--platforms',
+        'platforms',
+        'mt-4',
+        'mb-0',
+        appearance.orientation == 'h' ? 'inline horizontal' : 'vertical',
+    ]
+%}
+
+<ul{{attributes.addClass(classes)}}>
+	{% for platform in platforms %}
+		<li>
+			<a class="social-media-link-icon--{{ platform.id }} pe-3" href="{{ platform.url }}" {{ platform.attributes }}>
+				{{ platform.element }}
+			</a>
+
+			{% if appearance.show_name %}
+				{% if appearance.orientation == 'h' %}
+					<br/>
+				{% endif %}
+
+				<span>
+					<a class="social-media-link--{{ platform.id }}" href="{{ platform.url }}" {{ platform.attributes }}>{{ platform.name }}</a>
+				</span>
+			{% endif %}
+		</li>
+	{% endfor %}
+</ul>

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -26,7 +26,7 @@
  *   page's path (e.g. node/12345 and node/12345/revisions, but not
  *   comment/reply/12345).
  *
- * Regions: 
+ * Regions:
  * - page.above_header: Announcements and alerts, etc.
  * - page.header: Items for the header region.
  * - page.primary_menu: Items for the primary menu region.
@@ -57,7 +57,7 @@ set footer_classes = 'text-light'
 
   {% if page.nav_branding or page.nav_main or page.nav_additional %}
   <nav class="{{ nav_classes }}">
-    <div class="container d-flex">
+    <div class="container-fluid d-flex">
       {{ page.nav_branding }}
 
       {% if page.nav_main or page.nav_additional %}
@@ -94,13 +94,13 @@ set footer_classes = 'text-light'
   set content_classes = (has_sidebar_first and has_sidebar_second) ? 'col-12 col-lg-6' : ((has_sidebar_first or has_sidebar_second) ? 'col-12 col-lg-9' : 'col-12' )
   %}
 
-  <div class="container">
+  <div class="container-fluid my-4">
     {% if page.breadcrumb %}
       {{ page.breadcrumb }}
     {% endif %}
     <div class="row g-0">
       {% if has_sidebar_first %}
-        <div class="order-2 order-lg-1 {{ sidebar_first_classes }}">
+        <div class="order-2 order-lg-1 {{ sidebar_first_classes }} pe-lg-4">
           {{ page.sidebar_first }}
         </div>
       {% endif %}
@@ -108,7 +108,7 @@ set footer_classes = 'text-light'
         {{ page.content }}
       </div>
       {% if has_sidebar_second %}
-        <div class="order-3 {{ sidebar_second_classes }}">
+        <div class="order-3 {{ sidebar_second_classes }} ps-lg-4">
           {{ page.sidebar_second }}
         </div>
       {% endif %}
@@ -119,8 +119,26 @@ set footer_classes = 'text-light'
 
 {% if page.footer %}
 <footer class="mt-auto {{ footer_classes }}">
-  <div class="container">
-    {{ page.footer }}
+  <div class="container-fluid">
+
+    <div class="row">
+      <div class="col-12 col-md-4 mb-5">
+        {% if site_logo %}
+        <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home" class="site-logo d-block">
+          <img src="{{ site_logo }}" alt="{{ 'Home'|t }}" fetchpriority="high" />
+        </a>
+        {% endif %}
+        {{ page.footer_left }}
+      </div>
+      <div class="col-12 col-md-8 mb-5">
+        {{ page.footer }}
+      </div>
+      {% if page.footer_bottom %}
+      <div class="col">
+        {{ page.footer_bottom }}
+      </div>
+      {% endif %}
+    </div>
   </div>
 </footer>
 {% endif %}

--- a/templates/navigation/menu--footer.html.twig
+++ b/templates/navigation/menu--footer.html.twig
@@ -1,0 +1,73 @@
+{#
+/**
+ * @file
+ * Theme override to display a menu.
+ *
+ * Available variables:
+ * - menu_name: The machine name of the menu.
+ * - items: A nested list of menu items. Each menu item contains:
+ *   - attributes: HTML attributes for the menu item.
+ *   - below: The menu item child items.
+ *   - title: The menu link title.
+ *   - url: The menu link URL, instance of \Drupal\Core\Url
+ *   - localized_options: Menu link localized options.
+ *   - is_expanded: TRUE if the link has visible children within the current
+ *     menu tree.
+ *   - is_collapsed: TRUE if the link has children within the current menu tree
+ *     that are not currently visible.
+ *   - in_active_trail: TRUE if the link is in the active trail.
+ */
+#}
+{% import _self as menus %}
+
+{#
+  We call a macro which calls itself to render the full tree.
+  @see https://twig.symfony.com/doc/3.x/tags/macro.html
+#}
+<div class="row row-cols-2 row-cols-lg-4">
+  {{ menus.menu_links(items, attributes, 0) }}
+</div>
+
+{% macro menu_links(items, attributes, menu_level) %}
+  {% import _self as menus %}
+  {% if items %}
+    {% if menu_level != 0 %}
+      <ul class="nav flex-column">
+    {% endif %}
+
+    {% for item in items %}
+
+      {% if menu_level == 0 %}
+        {%
+          set classes_link = [
+            'nav-link',
+            item.in_active_trail ? 'active',
+            'text-white',
+          ]
+        %}
+        <div{{ attributes.addClass(['col', 'mb-4 mb-lg-0']) }}>
+          <h2 class="fs-6 text-uppercase">{{ link(item.title, item.url, { 'class': classes_link }) }}</h2>
+          {% if item.below %}
+            {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+          {% endif %}
+        </div>
+      {% else %}
+        {%
+          set classes_link = [
+            'nav-link',
+            item.in_active_trail ? 'active',
+          ]
+        %}
+        <li{{ item.attributes.addClass('nav-item') }}>
+          {{ link(item.title, item.url, { 'class': classes_link }) }}
+          {% if item.below %}
+            {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
+          {% endif %}
+        </li>
+      {% endif %}
+    {% endfor %}
+    {% if menu_level != 0 %}
+      </ul>
+    {% endif %}
+  {% endif %}
+{% endmacro %}


### PR DESCRIPTION
## Changes
* Switched to container-fluid in layout and set a max-width. 
* Adding 2 additional footer regions. Using bootstrap grid classes to change the layout.
* Adding logo to the footer (not a block but same logo as header)
* Updated the footer menu template to remove bootstrap dropdown functionality
* Adding template for social-media-links so we can us that module to add links to the footer. 
* Adding general footer styles
* Added `~` prefix to bootstrap imports to make it clearer that this is being pulled from node_modules.

### Desktop
![Screenshot 2024-04-15 at 12 56 00 PM](https://github.com/psu-libraries/psulib_base/assets/7094530/6caf3563-4b29-40fc-96bb-80eba3db1393)

### Tablet
![Screenshot 2024-04-15 at 12 56 13 PM](https://github.com/psu-libraries/psulib_base/assets/7094530/cb0019ec-4b25-41bf-a4e1-672741d59aba)

### Mobile
![Screenshot 2024-04-15 at 12 56 46 PM](https://github.com/psu-libraries/psulib_base/assets/7094530/0610d198-5af1-49cc-a8bc-4ec0d5721904)
