### PR TITLE
Issue #56 - Updating init to include all variables. Making variable d…

### DIFF
--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -84,22 +84,22 @@ $pa-link: #005fa9; // PA Link
 $pa-link-light: #cce9ff; // PA Link Light
 
 // Bootstrap color overrides.
-$blue: $nittany-navy;
-$indigo: $perpetual-wonder;
-$purple: $stately-atherton;
-$pink: $dawn-of-discovery;
-$red: $original-87;
-$orange: $invent-orange;
-$yellow: $bright-keystone;
-$green: $penns-forest;
-$teal: $pa-creek;
-$cyan: $pa-sky-light;
+$blue: $nittany-navy !default;
+$indigo: $perpetual-wonder !default;
+$purple: $stately-atherton !default;
+$pink: $dawn-of-discovery !default;
+$red: $original-87 !default;
+$orange: $invent-orange !default;
+$yellow: $bright-keystone !default;
+$green: $penns-forest !default;
+$teal: $pa-creek !default;
+$cyan: $pa-sky-light !default;
 
-$primary: $blue;
-$secondary: $pugh-blue;
-$success: $green;
-$info: $cyan;
-$warning: $yellow;
-$danger: $red;
-$light: $pa-limestome-max-light;
-$dark: $pa-slate;
+$primary: $blue !default;
+$secondary: $pugh-blue !default;
+$success: $green !default;
+$info: $cyan !default;
+$warning: $yellow !default;
+$danger: $red !default;
+$light: $pa-limestome-max-light !default;
+$dark: $pa-slate !default;

--- a/scss/_init.scss
+++ b/scss/_init.scss
@@ -1,14 +1,16 @@
+@import 'variables_drupal';
 @import 'variables_bootstrap';
 
 // 1. Include functions first (so you can manipulate colors, SVGs, calc, etc)
-@import "bootstrap/scss/functions";
+@import "~bootstrap/scss/functions";
 
 // 2. Include any default variable overrides here
 @import 'colors';
 
 // 3. Include remainder of required Bootstrap stylesheets (including any separate color mode stylesheets)
-@import 'bootstrap/scss/variables';
+@import '~bootstrap/scss/variables';
 
 // 5. Include remainder of required parts
-@import 'bootstrap/scss/maps';
-@import 'bootstrap/scss/mixins';
+@import '~bootstrap/scss/maps';
+@import '~bootstrap/scss/mixins';
+@import 'mixins';

--- a/scss/_variables_bootstrap.scss
+++ b/scss/_variables_bootstrap.scss
@@ -1,20 +1,20 @@
 @import 'colors';
 
 // Bootstrap variables (overrides).
-$form-text-margin-top: 0;
-$legend-font-size: 1rem;
-$table-cell-padding-x: .75rem;
+$form-text-margin-top: 0 !default;
+$legend-font-size: 1rem !default;
+$table-cell-padding-x: .75rem !default;
 
-$border-radius: 0;
+$border-radius: 0 !default;
 
 // Font overrides.
-$font-size-root: 18px;
-$font-family-sans-serif: Roboto, "Franklin Gothic Medium", Tahoma, sans-serif;
+$font-size-root: 18px !default;
+$font-family-sans-serif: Roboto, "Franklin Gothic Medium", Tahoma, sans-serif !default;
 
 // Overridding link colors and styles.
-$link-color: $pa-link;
-$link-hover-color: $pa-link;
-$link-hover-decoration: none;
+$link-color: $pa-link !default;
+$link-hover-color: $pa-link !default;
+$link-hover-decoration: none !default;
 
-$link-color-dark: $pa-link-light;
-$link-hover-color-dark: $pa-link-light;
+$link-color-dark: $pa-link-light !default;
+$link-hover-color-dark: $pa-link-light !default;


### PR DESCRIPTION
…efinitions defaults to allow subtheme to overridden them.

This allows subthemes to override base theme variables.  Example below:

```
// Variable Overrides.
$font-size-root: 16px;

// Include bootstrap.
@import '../../../../themes/contrib/psulib_base/scss/style';

```