### PR TITLE
Issue #59 - Adding 3 two column layouts based on bootstrap.

### DIFF
--- a/layouts/README.md
+++ b/layouts/README.md
@@ -1,0 +1,9 @@
+# Layouts for Layout Builder
+
+This contains layouts for layout builder built using Bootstrap grid or flex styles.
+
+## Resources
+
+- https://getbootstrap.com/docs/5.3/layout/grid/
+- https://getbootstrap.com/docs/5.3/utilities/flex/
+- ../psulib_base.layouts.yml

--- a/layouts/psul-one-column.html.twig
+++ b/layouts/psul-one-column.html.twig
@@ -1,0 +1,11 @@
+{% if content %}
+  <div {{ attributes.addClass('psul-one-column') }}>
+    <div class="row mb-4">
+    {% if content.main %}
+      <div {{ region_attributes.main.addClass(main_class) }}>
+        {{ content.main }}
+      </div>
+    {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/layouts/psul-two-column-33-66.html.twig
+++ b/layouts/psul-two-column-33-66.html.twig
@@ -17,7 +17,7 @@
 
 {% if content %}
   <div {{ attributes.addClass('psul-two-column ') }}>
-    <div class="row g-5 mb-4">
+    <div class="row g-4 g-lg-5 mb-4">
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>
         {{ content.main }}

--- a/layouts/psul-two-column-33-66.html.twig
+++ b/layouts/psul-two-column-33-66.html.twig
@@ -16,8 +16,8 @@
 %}
 
 {% if content %}
-  <div {{ attributes.addClass('psul-two-column') }}>
-    <div class="row">
+  <div {{ attributes.addClass('psul-two-column ') }}>
+    <div class="row g-5 mb-4">
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>
         {{ content.main }}

--- a/layouts/psul-two-column-33-66.html.twig
+++ b/layouts/psul-two-column-33-66.html.twig
@@ -1,0 +1,33 @@
+{%
+  set main_class = [
+    'psul-layout-column--main',
+    'col-12',
+    content.sidebar ? 'col-lg-8' : 'col-12',
+  ]
+%}
+
+{%
+  set sidebar_classes = [
+    'psul-layout-column--sidebar',
+    'col-12',
+    content.main ? 'col-lg-4' : 'col-12',
+    'order-lg-first',
+  ]
+%}
+
+{% if content %}
+  <div {{ attributes.addClass('psul-two-column') }}>
+    <div class="row">
+    {% if content.main %}
+      <div {{ region_attributes.main.addClass(main_class) }}>
+        {{ content.main }}
+      </div>
+    {% endif %}
+    {% if content.sidebar %}
+      <div {{ region_attributes.sidebar.addClass(sidebar_classes) }}>
+        {{ content.sidebar }}
+      </div>
+    {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/layouts/psul-two-column-33-66.html.twig
+++ b/layouts/psul-two-column-33-66.html.twig
@@ -17,7 +17,7 @@
 
 {% if content %}
   <div {{ attributes.addClass('psul-two-column ') }}>
-    <div class="row g-4 g-lg-5 mb-4">
+    <div class="row gy-3 gy-lg-0 gx-lg-5 mb-3 mb-lg-4">
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>
         {{ content.main }}

--- a/layouts/psul-two-column-50-50.html.twig
+++ b/layouts/psul-two-column-50-50.html.twig
@@ -16,7 +16,7 @@
 
 {% if content %}
   <div {{ attributes.addClass('psul-two-column') }}>
-    <div class="row g-4 g-lg-5 mb-4">
+    <div class="row gy-3 gy-lg-0 gx-lg-5 mb-3 mb-lg-4">
     {% if content.first %}
       <div {{ region_attributes.first.addClass(first_classes) }}>
         {{ content.first }}

--- a/layouts/psul-two-column-50-50.html.twig
+++ b/layouts/psul-two-column-50-50.html.twig
@@ -1,0 +1,32 @@
+{%
+  set first_classes = [
+    'psul-layout-column--first',
+    'col-12',
+    content.second ? 'col-lg-6' : 'col-12',
+  ]
+%}
+
+{%
+  set second_classes = [
+    'psul-layout-column--second',
+    'col-12',
+    content.first ? 'col-lg-6' : 'col-12',
+  ]
+%}
+
+{% if content %}
+  <div {{ attributes.addClass('psul-two-column') }}>
+    <div class="row">
+    {% if content.first %}
+      <div {{ region_attributes.first.addClass(first_classes) }}>
+        {{ content.first }}
+      </div>
+    {% endif %}
+    {% if content.second %}
+      <div {{ region_attributes.second.addClass(second_classes) }}>
+        {{ content.second }}
+      </div>
+    {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/layouts/psul-two-column-50-50.html.twig
+++ b/layouts/psul-two-column-50-50.html.twig
@@ -16,7 +16,7 @@
 
 {% if content %}
   <div {{ attributes.addClass('psul-two-column') }}>
-    <div class="row g-5 mb-4">
+    <div class="row g-4 g-lg-5 mb-4">
     {% if content.first %}
       <div {{ region_attributes.first.addClass(first_classes) }}>
         {{ content.first }}

--- a/layouts/psul-two-column-50-50.html.twig
+++ b/layouts/psul-two-column-50-50.html.twig
@@ -16,7 +16,7 @@
 
 {% if content %}
   <div {{ attributes.addClass('psul-two-column') }}>
-    <div class="row">
+    <div class="row g-5 mb-4">
     {% if content.first %}
       <div {{ region_attributes.first.addClass(first_classes) }}>
         {{ content.first }}

--- a/layouts/psul-two-column-66-33.html.twig
+++ b/layouts/psul-two-column-66-33.html.twig
@@ -16,7 +16,7 @@
 
 {% if content %}
   <div {{ attributes.addClass('psul-two-column') }}>
-    <div class="row g-4 g-lg-5 mb-4">
+    <div class="row gy-3 gy-lg-0 gx-lg-5 mb-3 mb-lg-4">
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>
         {{ content.main }}

--- a/layouts/psul-two-column-66-33.html.twig
+++ b/layouts/psul-two-column-66-33.html.twig
@@ -16,7 +16,7 @@
 
 {% if content %}
   <div {{ attributes.addClass('psul-two-column') }}>
-    <div class="row">
+    <div class="row g-5 mb-4">
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>
         {{ content.main }}

--- a/layouts/psul-two-column-66-33.html.twig
+++ b/layouts/psul-two-column-66-33.html.twig
@@ -1,0 +1,32 @@
+{%
+  set main_class = [
+    'psul-layout-column--main',
+    'col-12',
+    content.sidebar ? 'col-lg-8' : 'col-12',
+  ]
+%}
+
+{%
+  set sidebar_classes = [
+    'psul-layout-column--sidebar',
+    'col-12',
+    content.main ? 'col-lg-4' : 'col-12',
+  ]
+%}
+
+{% if content %}
+  <div {{ attributes.addClass('psul-two-column') }}>
+    <div class="row">
+    {% if content.main %}
+      <div {{ region_attributes.main.addClass(main_class) }}>
+        {{ content.main }}
+      </div>
+    {% endif %}
+    {% if content.sidebar %}
+      <div {{ region_attributes.sidebar.addClass(sidebar_classes) }}>
+        {{ content.sidebar }}
+      </div>
+    {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/layouts/psul-two-column-66-33.html.twig
+++ b/layouts/psul-two-column-66-33.html.twig
@@ -16,7 +16,7 @@
 
 {% if content %}
   <div {{ attributes.addClass('psul-two-column') }}>
-    <div class="row g-5 mb-4">
+    <div class="row g-4 g-lg-5 mb-4">
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>
         {{ content.main }}

--- a/psulib_base.layouts.yml
+++ b/psulib_base.layouts.yml
@@ -1,0 +1,38 @@
+psulib_two_col_33_66:
+  label: 'PSUL Two column 33/66'
+  category: 'PSU Libraries'
+  template: layouts/psul-two-column-33-66
+  default_region: main
+  regions:
+    main:
+      label: Main content
+    sidebar:
+      label: Sidebar
+  icon_map:
+    - [sidebar, main, main]
+
+psulib_two_col_50_50:
+  label: 'PSUL Two column 50/50'
+  category: 'PSU Libraries'
+  template: layouts/psul-two-column-50-50
+  default_region: first
+  regions:
+    first:
+      label: First column
+    second:
+      label: Second column
+  icon_map:
+    - [first, second]
+
+psulib_two_col_66_33:
+  label: 'PSUL Two column 66/33'
+  category: 'PSU Libraries'
+  template: layouts/psul-two-column-66-33
+  default_region: main
+  regions:
+    main:
+      label: Main content
+    sidebar:
+      label: Sidebar
+  icon_map:
+    - [main, main, sidebar]

--- a/psulib_base.layouts.yml
+++ b/psulib_base.layouts.yml
@@ -1,3 +1,14 @@
+psulib_one_col:
+  label: 'PSUL One column'
+  category: 'PSU Libraries'
+  template: layouts/psul-one-column
+  default_region: main
+  regions:
+    main:
+      label: Main content
+  icon_map:
+    - [main]
+
 psulib_two_col_33_66:
   label: 'PSUL Two column 33/66'
   category: 'PSU Libraries'


### PR DESCRIPTION
Adding 3 layouts that use bootstrap classes.  On mobile the 66/main column is first in both the 33-66 and 66-33 templates.

![Screenshot 2024-04-24 at 3 49 04 PM](https://github.com/psu-libraries/psulib_base/assets/7094530/0ad8e9b7-23ce-4f19-b698-a7b2db34a796)
![Screenshot 2024-04-24 at 3 48 01 PM](https://github.com/psu-libraries/psulib_base/assets/7094530/82f5bc0b-7c7f-4816-970a-8fd1245db8f8)
