### PR TITLE
Issue #111 - Removing SDC dependency from base theme so the module ca…

### DIFF
--- a/psulib_base.info.yml
+++ b/psulib_base.info.yml
@@ -8,8 +8,6 @@ libraries:
   - psulib_base/global-styling
   - psulib_base/bootstrap-icons
   - sdc/psulib_base--alert_banner
-dependencies:
-  - drupal:sdc
 logo: 'logo.png'
 regions:
   above_header: Above Header (announcements, alerts, etc.)


### PR DESCRIPTION
…n be uninstalled.

Super simple PR but the SDC module can now be uninstalled (checkbox is no longer disabled). (see https://psul-web.psul.localhost/admin/modules/uninstall)

<img width="1251" alt="Screenshot 2024-07-01 at 8 43 53 AM" src="https://github.com/psu-libraries/psulib_base/assets/7094530/eed9c8f1-5319-43c5-a905-f65ac2a7c8e2">
