### PR TITLE
122 decrease header logo on small screens prevent header overflow

### DIFF
--- a/components/footer/footer.twig
+++ b/components/footer/footer.twig
@@ -6,7 +6,7 @@
       <div class="col-12 col-md-4 mb-5">
         {% if site_logo %}
         <a href="{{ site_logo_url }}" title="{{ site_logo_alt }}" rel="home" class="site-logo d-block">
-          <img src="{{ site_logo }}" alt="{{ site_logo_alt }}" fetchpriority="high" />
+          <img src="{{ site_logo }}" alt="{{ site_logo_alt }}" fetchpriority="high" height="52" width="198"/>
         </a>
         {% endif %}
         {% block footer_left %}{% endblock %}

--- a/components/header/header.scss
+++ b/components/header/header.scss
@@ -54,12 +54,17 @@ header {
 
   .nav-actions {
     padding: $nav-link-padding-y;
+    font-size: $font-size-sm;
 
     @include media-breakpoint-down(md) {
       display: block;
       width: 100%;
       background-color: $beaver-blue;
       padding: var(--bs-navbar-padding-y) $grid-gutter-width;
+    }
+
+    @include media-breakpoint-up('lg') {
+      font-size: $font-size-base;
     }
   }
 
@@ -140,6 +145,7 @@ header {
 .navbar-brand {
   white-space: unset;
   @include make-link($light, none, $light, underline, '.site-title');
+  flex-shrink: 1;
 
   .site-slogan {
     display: none;
@@ -161,6 +167,19 @@ header {
     margin: 0;
     width: $navbar-brand-image-width;
     @include media-breakpoint-up(lg) {
+      margin: $navbar-brand-image-margin;
+      height: $navbar-brand-image-height-lg;
+    }
+  }
+
+  img {
+    height: auto;
+    margin: 0;
+    width: 75%;
+    max-width: 228px;
+    @include media-breakpoint-up(lg) {
+      width: $navbar-brand-image-width;
+      max-width: $navbar-brand-image-width;
       margin: $navbar-brand-image-margin;
       height: $navbar-brand-image-height-lg;
     }

--- a/scss/_variables_bootstrap.scss
+++ b/scss/_variables_bootstrap.scss
@@ -19,3 +19,6 @@ $link-hover-decoration: none !default;
 
 $link-color-dark: $pa-link-light !default;
 $link-hover-color-dark: $pa-link-light !default;
+
+// Increasing navbar padding-y to add more space on mobile.
+$navbar-brand-padding-y: .75rem;

--- a/scss/base/_layout.scss
+++ b/scss/base/_layout.scss
@@ -10,9 +10,11 @@
   }
 }
 
-.region-nav-branding,
-.region-nav-additional {
-  flex-shrink: 0;
+@include media-breakpoint-up('md') {
+  .region-nav-branding,
+  .region-nav-additional {
+    flex-shrink: 0;
+  }
 }
 
 // Add a max width the container-fluid and increasing padding on larger

--- a/templates/block/block--system-branding-block.html.twig
+++ b/templates/block/block--system-branding-block.html.twig
@@ -18,10 +18,9 @@
 
   {% if site_logo %}
   <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home" class="site-logo d-block">
-    <img src="{{ site_logo }}" alt="{{ 'Home'|t }}" fetchpriority="high" />
+    <img src="{{ site_logo }}" alt="{{ 'Home'|t }}" fetchpriority="high" height="60" width="228" />
   </a>
   {% endif %}
-
   <div>
     {% if site_name %}
     <a href="{{ path('<front>') }}" title="{{ 'Home'|t }}" rel="home" class="site-title hidden">


### PR DESCRIPTION
Minor tweaks to the header to fix the following issues:

## Changes
- Adding width and height attributes to header and footer logo to reduce layout shift
- Adjusting styles so prevent overflow on mobile header (shrinking PSU logo and changing flex)
- Decreasing font-size on nav actions to reduce likelihood of main nav wrapping.

<img width="820" alt="Screenshot 2024-07-22 at 10 06 49 AM" src="https://github.com/user-attachments/assets/98c9cf5d-0a84-48ba-97e2-e958c945b942">
<img width="343" alt="Screenshot 2024-07-22 at 10 06 57 AM" src="https://github.com/user-attachments/assets/731f0688-31ba-4838-b124-bc26a53b0e33">
