### PR TITLE
Issue #129 - Making the sidebar region second to fix tab order and im…

### DIFF
--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -82,14 +82,14 @@ set footer_classes = 'text-light'
       {{ page.breadcrumb }}
     {% endif %}
     <div class="row g-0">
+      <div class="order-1 order-lg-2 {{ content_classes }}">
+        {{ page.content }}
+      </div>
       {% if has_sidebar_first %}
         <div class="order-2 order-lg-1 {{ sidebar_first_classes }} pe-lg-4">
           {{ page.sidebar_first }}
         </div>
       {% endif %}
-      <div class="order-1 order-lg-2 {{ content_classes }}">
-        {{ page.content }}
-      </div>
       {% if has_sidebar_second %}
         <div class="order-3 {{ sidebar_second_classes }} ps-lg-4">
           {{ page.sidebar_second }}


### PR DESCRIPTION
…prove experience with screen readers.

The columns retain the same visual order due to the `order-*` classes but this changes the tab order put the content before the sidebar.