### PR TITLE
138 port headermain nav styles to base theme

### DIFF
--- a/components/button/button.scss
+++ b/components/button/button.scss
@@ -8,7 +8,8 @@ $btn-rounded-radius: .3rem !default;
   --#{$prefix}btn-rounded-radius: #{$btn-rounded-radius};
 }
 
-// Import bootstrap pagination styles.
+// Import bootstrap button styles and mixins.
+@import '~bootstrap/scss/mixins/_buttons.scss';
 @import '~bootstrap/scss/buttons';
 
 // Custom styles go here.

--- a/components/header/header.component.yml
+++ b/components/header/header.component.yml
@@ -2,6 +2,9 @@ name: Header
 props:
   type: object
   properties: {}
+libraryOverrides:
+  dependencies:
+    - psulib_base/nav
 slots:
   above_header:
     title: Above Header

--- a/components/header/header.js
+++ b/components/header/header.js
@@ -1,0 +1,72 @@
+(function (Drupal, once) {
+  Drupal.behaviors.mainMenu = {
+    attach: function (context) {
+      const desktopBreakpoint = 768;
+
+      function setupDropdownBehavior(navElement) {
+        navElement.querySelectorAll('.navbar-nav .dropdown').forEach(item => {
+          const link = item.querySelector('.nav-link.dropdown-toggle');
+          const arrow = item.querySelector('.dropdown-arrow svg');
+          const dropdownMenu = item.querySelector('.dropdown-menu');
+
+          if (link && arrow && dropdownMenu) {
+            item.addEventListener('mouseenter', () => {
+              if (window.innerWidth >= desktopBreakpoint) openDropdown(item);
+            });
+
+            item.addEventListener('mouseleave', () => {
+              if (window.innerWidth >= desktopBreakpoint) closeDropdown(item);
+            });
+
+            link.addEventListener('click', e => {
+              window.location.href = link.getAttribute('href');
+            });
+
+            arrow.addEventListener('click', e => {
+              e.preventDefault();
+              toggleDropdown(item);
+            });
+          }
+        });
+      }
+
+      function openDropdown(item) {
+        item.classList.add('show');
+        item.querySelector('.dropdown-menu').style.cssText = 'max-height: 1200px; opacity: 1;';
+        const arrow = item.querySelector('.dropdown-arrow svg');
+        arrow.style.transform = 'rotate(180deg)';
+        arrow.setAttribute('aria-expanded', 'true');
+      }
+
+      function closeDropdown(item) {
+        item.classList.remove('show');
+        item.querySelector('.dropdown-menu').style.cssText = 'max-height: 0; opacity: 0;';
+        const arrow = item.querySelector('.dropdown-arrow svg');
+        arrow.style.transform = 'rotate(0deg)';
+        arrow.setAttribute('aria-expanded', 'false');
+      }
+
+      function toggleDropdown(item) {
+        if(item.classList.contains('show')) {
+          closeDropdown(item);
+        } else {
+          openDropdown(item);
+        }
+      }
+
+      function closeAllDropdowns(navElement) {
+        navElement.querySelectorAll('.nav-item.show').forEach(closeDropdown);
+      }
+
+
+      once('psul-theme-mainMenuNav', '#mainMenuNav', context).forEach(() => {
+        document.querySelectorAll('#mainMenuNav').forEach(setupDropdownBehavior);
+      });
+
+      once('psul-theme-offcanvasMain', '#offcanvasMain', context).forEach(() => {
+        document.querySelectorAll('#offcanvasMain').forEach(setupDropdownBehavior);
+      });
+
+    }
+  };
+})(Drupal, once);

--- a/components/header/header.scss
+++ b/components/header/header.scss
@@ -12,9 +12,11 @@ header {
   @include make-link($light, none, $pa-sky-light, underline);
 
   .navbar {
+    // Overriding the navbar padding. Not 100% sure why.
+    --bs-navbar-padding-y: 0px;
     flex-wrap: wrap;
 
-    & > .container-fluid {
+    &>.container-fluid {
       display: block;
     }
   }
@@ -23,7 +25,9 @@ header {
     color: $white-out;
     border: 0;
 
-    &:hover, &:active, &:focus {
+    &:hover,
+    &:active,
+    &:focus {
       border: 0;
       color: var(--bs-blue);
       background-color: var(--bs-cyan);
@@ -31,36 +35,36 @@ header {
   }
 
   .nav-item {
-      font-family: $font-family-condensed;
+    font-family: $font-family-condensed;
   }
 
   .navbar-nav {
 
-      .nav-link,
-      .nav-link.active,
-      .nav-link.show {
-          color: $white-out;
+    .nav-link,
+    .nav-link.active,
+    .nav-link.show {
+      color: $white-out;
+    }
+
+    .nav-link {
+
+      &:hover {
+        color: $pa-sky-light;
       }
 
-      .nav-link {
-
-          &:hover {
-            color: $pa-sky-light;
-          }
-
-      }
+    }
 
   }
 
   .nav-actions {
-    padding: $nav-link-padding-y;
+    padding: 0 $nav-link-padding-y;
     font-size: $font-size-sm;
 
     @include media-breakpoint-down(md) {
       display: block;
       width: 100%;
       background-color: $beaver-blue;
-      padding: var(--bs-navbar-padding-y) $grid-gutter-width;
+      padding: $nav-link-padding-y $grid-gutter-width;
     }
 
     @include media-breakpoint-up('lg') {
@@ -74,7 +78,7 @@ header {
   }
 
   .region-nav-additional {
-      font-size: $font-size-sm;
+    font-size: $font-size-sm;
   }
 
   .block-search {
@@ -89,6 +93,7 @@ header {
 
       .form-actions {
         margin-top: divide($spacer, 2);
+
         @include media-breakpoint-up(md) {
           margin-left: divide($spacer, 2);
           margin-top: 0;
@@ -110,6 +115,119 @@ header {
     }
   }
 
+  .block-menu.menu--main .navbar-nav {
+    gap: 40px;
+
+    .dropdown-menu {
+      padding: 20px 10px;
+      left: 0;
+      top: 100%;
+      animation: none;
+      border-top: 7px solid $pa-link-light;
+
+      @include media-breakpoint-up('md') {
+        position: absolute;
+      }
+    }
+
+    li {
+      position: relative;
+
+      .link-container {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      a {
+        padding: 0 0 15px 0;
+        font-size: $font-size-sm;
+        font-weight: 500;
+        font-family: $font-family-condensed;
+
+        &:hover {
+          color: $pa-link-light;
+          text-decoration: none;
+        }
+
+        &.dropdown-item {
+          padding: 3px 10px;
+          border-radius: 4px;
+          border-color: transparent;
+          margin: 5px;
+
+          &:hover {
+            color: $primary-color;
+            background-color: #ccc;
+            border-color: #ccc;
+          }
+        }
+
+        @include media-breakpoint-up('lg') {
+          font-size: $font-size-base;
+        }
+      }
+
+      .dropdown-arrow {
+        cursor: pointer;
+        display: block;
+        margin-top: -16px;
+        padding-left: 10px;
+
+        svg {
+          width: 16px;
+          height: 16px;
+        }
+      }
+
+      .dropdown-menu {
+        display: none;
+        max-height: 0;
+        opacity: 0;
+        transition: max-height 0.3s ease, opacity 0.3s ease;
+        width: 300px
+      }
+
+      &.show .dropdown-menu {
+        display: block;
+        max-height: 1200px;
+        opacity: 1;
+      }
+    }
+
+    @include media-breakpoint-up(md) {
+      .dropdown:hover>.dropdown-menu {
+        display: block;
+      }
+    }
+  }
+
+  /**
+   * Top bar navigation with 'my acct', etc
+   */
+  ul[data-block="nav_additional"] {
+    text-transform: uppercase;
+
+    // @todo make this an actual button variant.
+    a.btn.button.btn-primary.btn-nav-additional.nav-link {
+      font-size: 15.75px;
+      border-radius: 30px;
+      border-color: $psu-light-blue;
+      margin: 7px 10px;
+      padding: 0 20px;
+      text-transform: none;
+      font-family: $font-family-sans-serif;
+      font-weight: 400;
+
+      &:hover {
+        text-decoration: none;
+        border-color: $navy-blue;
+        background-color: $navy-blue;
+        color: white;
+      }
+    }
+  }
+
 }
 
 .navbar-nav {
@@ -124,18 +242,20 @@ header {
       align-items: center;
     }
   }
+
   .dropdown:hover .dropdown-menu {
     display: block;
   }
 
   .dropdown-menu {
-      animation: .5s slideup;
-    }
+    animation: none;
+  }
 
   @keyframes slideup {
     from {
       transform: translateY(25px);
     }
+
     to {
       transform: translateY(0);
     }
@@ -150,6 +270,7 @@ header {
   .site-slogan {
     display: none;
     font-size: $navbar-brand-site-slogan-font-size;
+
     @include media-breakpoint-up(lg) {
       display: block;
     }
@@ -166,6 +287,7 @@ header {
     height: $navbar-brand-image-height;
     margin: 0;
     width: $navbar-brand-image-width;
+
     @include media-breakpoint-up(lg) {
       margin: $navbar-brand-image-margin;
       height: $navbar-brand-image-height-lg;
@@ -177,6 +299,7 @@ header {
     margin: 0;
     width: 75%;
     max-width: 228px;
+
     @include media-breakpoint-up(lg) {
       width: $navbar-brand-image-width;
       max-width: $navbar-brand-image-width;
@@ -184,4 +307,140 @@ header {
       height: $navbar-brand-image-height-lg;
     }
   }
+}
+
+// @todo origanize this garbage.
+
+/**
+ * Header styles
+ * @todo Port these to the base theme.
+ */
+.offcanvas__main {
+
+  ul {
+    background-color: transparent;
+    border: 0;
+
+    li.nav-item {
+      a {
+        font-weight: bold;
+
+        &.is-active,
+        &.active {
+          color: black;
+
+          &:before {
+            content: "";
+            position: absolute;
+            left: -5px;
+            top: 50%;
+            transform: translateY(-50%);
+            height: 25px;
+            width: 50%;
+            border-left: 5px solid $psu-light-blue;
+          }
+        }
+      }
+    }
+  }
+
+  .link-container {
+    position: relative;
+
+    span.dropdown-arrow {
+      position: absolute;
+      right: 20px;
+      top: 50%;
+      transform: translateY(-50%);
+      cursor: pointer;
+    }
+  }
+
+  nav ul.navbar-nav {
+
+    a,
+    a.button {
+      word-wrap: break-word;
+      text-align: left;
+      text-decoration: none;
+      color: $black;
+      display: block;
+      background-color: transparent;
+      border: 0;
+    }
+
+    .dropdown-menu {
+      border: 0;
+      padding: 0;
+      margin: 0;
+
+      .dropdown-item {
+        white-space: normal;
+      }
+    }
+  }
+}
+
+header,
+.offcanvas__main {
+
+  /* Common styles for dropdown arrow */
+  .dropdown-arrow {
+    cursor: pointer;
+    transition: transform 0.3s ease;
+
+    svg {
+      transition: transform 0.3s ease;
+    }
+  }
+
+  /* Navigation dropdown behavior */
+  .navbar-nav {
+    .dropdown-menu {
+      max-height: 0;
+      opacity: 0;
+      overflow: hidden;
+      transition: max-height 0.3s ease, opacity 0.3s ease;
+
+      .dropdown-menu {
+        display: none;
+      }
+    }
+
+    .dropdown.show>.dropdown-menu,
+    .dropdown.show>.dropdown-menu>.dropdown.show>.dropdown-menu {
+      display: block;
+      max-height: 1200px;
+      opacity: 1;
+    }
+  }
+
+  /* Desktop Navigation dropdown behavior */
+  @include media-breakpoint-up('md') {
+    .navbar-nav {
+      .dropdown-menu {
+        display: none;
+        max-height: none;
+        opacity: 1;
+        transition: none;
+      }
+
+      .dropdown:hover .dropdown-menu {
+        display: block;
+      }
+
+      .dropdown:hover .dropdown-arrow svg {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+}
+
+/* Special rule to hide the bs dropdown arrows */
+header a.nav-link.dropdown-toggle::after,
+.offcanvas__main a.nav-link.dropdown-toggle::after {
+  display: none !important;
+  content: "";
+  border: 0;
 }

--- a/components/header/header.twig
+++ b/components/header/header.twig
@@ -50,7 +50,7 @@ set nav_classes = 'navbar navbar-expand-lg text-light'
   </nav>
 </header>
 
-<div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasMain">
+<div class="offcanvas offcanvas-end offcanvas__main" tabindex="-1" id="offcanvasMain">
   <div class="offcanvas-header">
     <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
   </div>

--- a/components/sidebar_menu/sidebar_menu.scss
+++ b/components/sidebar_menu/sidebar_menu.scss
@@ -1,5 +1,4 @@
-@use "sass:map";
-@import '../../../../../themes/contrib/psulib_base/scss/init';
+@import '../../scss/init';
 
 // Adding menu block heading styles.
 .block-menu:has(.sidebar-menu) .block-menu--title {

--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,5 +1,5 @@
 {
-    "/dist/css/placeholders.css": "/dist/css/placeholders.css",
+    "/dist/css/nav.css": "/dist/css/nav.css",
     "/dist/css/general.css": "/dist/css/general.css",
     "/dist/css/file.css": "/dist/css/file.css",
     "/dist/css/carousel.css": "/dist/css/carousel.css",
@@ -12,12 +12,12 @@
     "/components/header/header.css": "/components/header/header.css",
     "/components/footer/footer.css": "/components/footer/footer.css",
     "/components/card/card.css": "/components/card/card.css",
-    "/components/button/button.css": "/components/button/button.css",
     "/components/breadcrumbs/breadcrumbs.css": "/components/breadcrumbs/breadcrumbs.css",
     "/components/alert/alert.css": "/components/alert/alert.css",
     "/components/alert_banner/alert_banner.css": "/components/alert_banner/alert_banner.css",
     "/dist/css/search-results.css": "/dist/css/search-results.css",
     "/dist/css/progress.css": "/dist/css/progress.css",
+    "/dist/css/placeholders.css": "/dist/css/placeholders.css",
     "/dist/js/application.js": "/dist/js/application.js",
     "/dist/js/bootstrap.bundle.js": "/dist/js/bootstrap.bundle.js",
     "/dist/js/bootstrap.bundle.js.map": "/dist/js/bootstrap.bundle.js.map",
@@ -32,5 +32,6 @@
     "/dist/js/bootstrap.min.js": "/dist/js/bootstrap.min.js",
     "/dist/js/bootstrap.min.js.map": "/dist/js/bootstrap.min.js.map",
     "/dist/js/popper.min.js": "/dist/js/popper.min.js",
-    "/dist/js/popper.min.js.map": "/dist/js/popper.min.js.map"
+    "/dist/js/popper.min.js.map": "/dist/js/popper.min.js.map",
+    "/components/button/button.css": "/components/button/button.css"
 }

--- a/psulib_base.libraries.yml
+++ b/psulib_base.libraries.yml
@@ -14,6 +14,7 @@ global-styling:
     - core/once
     - psulib_base/bootstrap
     - psulib_base/bootstrap-icons
+    - psulib_base/nav
     - core/components.psulib_base--button
 
 # including bootstrap javascript and icons.
@@ -63,6 +64,11 @@ file:
   css:
     component:
       dist/css/file.css: {}
+
+nav:
+  css:
+    component:
+      dist/css/nav.css: {}
 
 placeholders:
   css:

--- a/scss/components/general.scss
+++ b/scss/components/general.scss
@@ -3,6 +3,11 @@
  * Component level styles that should be loaded on all pages.
  */
 
+* {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale
+}
+
 // Action links.
 .action-links {
     margin: 1em 0;

--- a/scss/components/nav.scss
+++ b/scss/components/nav.scss
@@ -1,0 +1,15 @@
+// Generate styles for pagination.
+@import '../init';
+
+// Override variables here:
+
+// Import bootstrap nav and navbar styles.
+@import "~bootstrap/scss/nav";
+@import "~bootstrap/scss/navbar";
+@import "~bootstrap/scss/dropdown";
+
+// Additional Styles for navs and dropdowns.
+.dropdown-toggle,
+.dropdown-item {
+  text-wrap: wrap;
+}

--- a/scss/style.scss
+++ b/scss/style.scss
@@ -30,13 +30,10 @@
 @import "~bootstrap/scss/grid";
 @import "~bootstrap/scss/tables";
 @import "~bootstrap/scss/forms";
-@import "~bootstrap/scss/dropdown";
 @import "~bootstrap/scss/transitions";
 @import "~bootstrap/scss/badge";
 @import "~bootstrap/scss/list-group";
 @import "~bootstrap/scss/close";
-@import "~bootstrap/scss/nav";
-@import "~bootstrap/scss/navbar";
 @import "~bootstrap/scss/helpers";
 
 // 7. Optionally include utilities API last to generate classes based on the Sass map in `_utilities.scss`


### PR DESCRIPTION
Porting header and main menu style changes from the base theme.  This also includes:

- Fix from https://github.com/orgs/psu-libraries/projects/29/views/4?sliceBy%5Bvalue%5D=Sprint+9+-+Release&pane=issue&itemId=73214201
- Webkit antialiasing fix to make fonts clearer
- First stab at cleaning up header styles
- Splitting nav into a separate library (some header styles should go in here)