### PR TITLE
62 sdc port accordion component to base theme

### DIFF
--- a/components/accordion/accordion.component.yml
+++ b/components/accordion/accordion.component.yml
@@ -1,0 +1,79 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/10.1.x/core/modules/sdc/src/metadata.schema.json
+name: Accordion
+status: stab;le
+description: 'Accordion component, see Bootstrap Documentation: https://getbootstrap.com/docs/5.3/components/accordion/'
+props:
+  type: object
+  properties:
+    title:
+      type: string
+      title: Title
+      description: Title text for the accordion.
+      default: ''
+    title_tag:
+      type: string
+      title: Title Tag
+      description: HTML tag for the title.
+      enum:
+        - h1
+        - h2
+        - h3
+        - h4
+        - h5
+        - h6
+      default: h2
+    title_link:
+      type: string
+      title: Title Link
+      description: URL for the title link.
+      default: ''
+    title_attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: A list of HTML attributes for the button.
+    id:
+      type: ['integer', 'string']
+      title: ID
+      description: Unique ID for the accordion component.
+      default: 0
+    flush:
+      type: boolean
+      title: Flush
+      description: True if the accordion has no background color or borders.
+      default: false
+    items:
+      type: array
+      title: Items
+      description: An array of items inside the accordion. Each item is an object that has title, content, and stay_open properties.
+      default: [{}]
+    open_item_id:
+      type: integer
+      title: Open Item ID
+      description: The index of the item that should be opened by default.
+      default: 0
+    accordion_utility_classes:
+      type: array
+      items:
+        type: string
+      title: Accordion Utility Classes
+      default: []
+      description: An array of utility classes. Use to add extra Bootstrap utility classes or custom CSS classes over to this component.
+    accordion_item_utility_classes:
+      type: array
+      items:
+        type: string
+      title: Accordion Item Utility Classes
+      default: []
+      description: An array of utility classes. Use to add extra Bootstrap utility classes or custom CSS classes over to this component.
+    accordion_attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Attributes
+      description: A list of HTML attributes for the accordion.
+    accordion_item_attributes:
+      type: Drupal\Core\Template\Attribute
+      title: Item Attributes
+      description: A list of HTML attributes for the accordion items.
+slots:
+  content:
+    title: Content
+    description: Default content text for the accordion.

--- a/components/accordion/accordion.component.yml
+++ b/components/accordion/accordion.component.yml
@@ -22,6 +22,17 @@ props:
         - h5
         - h6
       default: h2
+    default_item_tag:
+      type: string
+      title: Accordion Title Tag
+      description: HTML tag for the Accordion Title. This can be overridden in the item.
+      enum:
+        - h2
+        - h3
+        - h4
+        - h5
+        - h6
+      default: h3
     title_link:
       type: string
       title: Title Link

--- a/components/accordion/accordion.scss
+++ b/components/accordion/accordion.scss
@@ -1,0 +1,56 @@
+@import '../../scss/init';
+
+@import '~bootstrap/scss/accordion';
+
+.accordion {
+  position: relative;
+  z-index: 1;
+  color: $pa-limestome-max-light;
+
+  .accordion-item {
+    border: 0;
+
+    .accordion-button {
+      margin: .5rem 0;
+      padding: 0.75rem 1rem;
+      transition: all 0.2s ease-in-out;
+      background-color: $pa-limestome-max-light;
+      color: $primary;
+      border: 0;
+
+      .accordion-header {
+        font-size: 1.1rem;
+        margin: 0 1rem 0 0;
+      }
+
+      &:first-of-type {
+        margin-top: 0;
+      }
+
+      &:hover {
+        background-color: $pa-limestone-light;
+        border: 0;
+      }
+
+      &:not(.collapsed) {
+        background-color: $primary;
+        color: white;
+        border: 0;
+        border-image-width: 0;
+      }
+
+      &:after {
+        background-size: 30px 30px;
+        background-position: center center;
+      }
+
+      &:not(.collapsed)::after {
+        background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%23ffffff%22%20class%3D%22bi%20bi-dash%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M4%208a.5.5%200%200%201%20.5-.5h7a.5.5%200%200%201%200%201h-7A.5.5%200%200%201%204%208%22%2F%3E%3C%2Fsvg%3E");
+      }
+
+      &.collapsed::after {
+        background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%23001e44%22%20class%3D%22bi%20bi-plus%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8%204a.5.5%200%200%201%20.5.5v3h3a.5.5%200%200%201%200%201h-3v3a.5.5%200%200%201-1%200v-3h-3a.5.5%200%200%201%200-1h3v-3A.5.5%200%200%201%208%204%22%2F%3E%3C%2Fsvg%3E ");
+      }
+    }
+  }
+}

--- a/components/accordion/accordion.twig
+++ b/components/accordion/accordion.twig
@@ -12,6 +12,7 @@
   * Available properties:
   * - title (string) (default: '')
   * - title_tag (string) (default: 'h2')
+  * - default_item_tag (string) (default: 'h3')
   * - title_link: (link object) (default: {})
   * - title_attributes: (drupal attrs)
   * - id (int) (default: accordion-random(1000))
@@ -34,6 +35,7 @@
 
 {% set title = title|default('') %}
 {% set title_tag = title_tag|default('h2') %}
+{% set default_item_tag = default_item_tag|default('h3') %}
 {% set title_link = title_link|default({}) %}
 {% set title_attributes = title_attributes ?: create_attribute() %}
 {% set id = id|default('accordion-' ~ random(1000)) %}
@@ -66,7 +68,7 @@
     {% if title is not empty %}
       {%
         include 'psulib_base:heading' with {
-          heading_html_tag: 'h2',
+          heading_html_tag: title_tag,
           content: title,
           heading_attributes: title_attributes,
         }
@@ -89,7 +91,7 @@
 
       {% if content %}
         <div {{ accordion_item_attributes.addClass(accordion_item_classes) }}>
-          {% set item_title_tag = item.title_tag|default('h3') %}
+          {% set item_title_tag = item.title_tag|default(default_item_tag) %}
 
           <{{item_title_tag}} class="accordion-header" id="heading-{{ id }}-{{ loop.index }}">
             {%

--- a/components/accordion/accordion.twig
+++ b/components/accordion/accordion.twig
@@ -1,0 +1,127 @@
+{#
+/**
+  * @file
+  * Accordion component.
+  *
+  * Bootstrap Documentation
+  * https://getbootstrap.com/docs/5.3/components/accordion/
+  *
+  * Full List Utility Classes
+  * https://github.com/twbs/bootstrap/blob/v5.3.0/dist/css/bootstrap.css#L214
+  *
+  * Available properties:
+  * - title (string) (default: '')
+  * - title_tag (string) (default: 'h2')
+  * - title_link: (link object) (default: {})
+  * - title_attributes: (drupal attrs)
+  * - id (int) (default: accordion-random(1000))
+  * - flush (boolean) (default: false)
+  * - items (array) (default: []): format: [
+  *     {
+  *       title: (string),
+  *       title_tag: (string),
+  *       content: (block),
+  *       stay_open (boolean) (default: false)
+  *     },
+  *   ]
+  * - open_item_id (int) (default: 0)
+  *
+  * usage example: @see README.md
+  *
+  */
+#}
+{% apply spaceless %}
+
+{% set title = title|default('') %}
+{% set title_tag = title_tag|default('h2') %}
+{% set title_link = title_link|default({}) %}
+{% set title_attributes = title_attributes ?: create_attribute() %}
+{% set id = id|default('accordion-' ~ random(1000)) %}
+{% set flush = flush ?? false %}
+{% set items = items|default([]) %}
+{% set open_item_id = open_item_id|default(0) %}
+
+{%
+  set accordion_classes = [
+    'accordion'
+  ]|merge(accordion_utility_classes ?: [])
+%}
+
+{%
+  set accordion_item_classes = [
+    'accordion-item'
+  ]|merge(accordion_item_utility_classes ?: [])
+%}
+
+{% if flush %}
+  {% set accordion_classes = accordion_classes|merge(['accordion-flush']) %}
+{% endif %}
+
+{% set accordion_attributes = accordion_attributes ?: create_attribute() %}
+{% set accordion_item_attributes = accordion_item_attributes ?: create_attribute() %}
+{% set accordion_attributes = accordion_attributes.addClass(accordion_classes).setAttribute('id', id) %}
+
+{% if items is not empty %}
+  <div {{ accordion_attributes.addClass(accordion_classes) }}>
+    {% if title is not empty %}
+      {%
+        include 'psulib_base:heading' with {
+          heading_html_tag: 'h2',
+          content: title,
+          heading_attributes: title_attributes,
+        }
+      %}
+    {% endif %}
+
+    {% for item in items %}
+      {% set content = item.content|default('') %}
+      {% set open_item = open_item_id == loop.index %}
+      {%
+        set button_classes = [
+          'accordion-button',
+          'text-wrap',
+        ]
+      %}
+
+      {% if not open_item %}
+        {% set button_classes = button_classes|merge(['collapsed']) %}
+      {% endif %}
+
+      {% if content %}
+        <div {{ accordion_item_attributes.addClass(accordion_item_classes) }}>
+          {% set item_title_tag = item.title_tag|default('h3') %}
+
+          <{{item_title_tag}} class="accordion-header" id="heading-{{ id }}-{{ loop.index }}">
+            {%
+              set button_attributes = create_attribute()
+                .addClass(button_classes)
+                .setAttribute('data-bs-toggle', 'collapse')
+                .setAttribute('autocomplete', 'off')
+                .setAttribute('data-bs-target', '#collapse-' ~ id ~ '-' ~ loop.index)
+                .setAttribute('aria-controls', 'collapse-' ~ id ~ '-' ~ loop.index)
+                .setAttribute('aria-expanded', open_item ? 'true' : 'false')
+            %}
+
+            {%
+              include 'psulib_base:button' with {
+                content: item.title,
+                button_attributes,
+                id: 'button-' ~ '-' ~ id ~'-' ~ loop.index
+              }
+            %}
+          </{{item_title_tag}}>
+
+          <div id="collapse-{{ id }}-{{ loop.index }}" class="accordion-collapse collapse{{ open_item ? ' show' }}" aria-labelledby="heading-{{ id }}-{{ loop.index }}" role="region" {% if not item.stay_open %} data-bs-parent="#{{ id }}" {% endif %}>
+            <div class="accordion-body">
+              {% block content %}
+                {{ content }}
+              {% endblock %}
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+{% endif %}
+
+{% endapply %}

--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,9 +1,9 @@
 {
+    "/dist/css/placeholders.css": "/dist/css/placeholders.css",
     "/dist/css/nav.css": "/dist/css/nav.css",
     "/dist/css/general.css": "/dist/css/general.css",
     "/dist/css/file.css": "/dist/css/file.css",
     "/dist/css/carousel.css": "/dist/css/carousel.css",
-    "/dist/css/accordion.css": "/dist/css/accordion.css",
     "/dist/css/style.css": "/dist/css/style.css",
     "/components/sidebar_menu/sidebar_menu.css": "/components/sidebar_menu/sidebar_menu.css",
     "/components/person/person.css": "/components/person/person.css",
@@ -19,7 +19,6 @@
     "/components/accordion/accordion.css": "/components/accordion/accordion.css",
     "/dist/css/search-results.css": "/dist/css/search-results.css",
     "/dist/css/progress.css": "/dist/css/progress.css",
-    "/dist/css/placeholders.css": "/dist/css/placeholders.css",
     "/dist/js/application.js": "/dist/js/application.js",
     "/dist/js/bootstrap.bundle.js": "/dist/js/bootstrap.bundle.js",
     "/dist/js/bootstrap.bundle.js.map": "/dist/js/bootstrap.bundle.js.map",

--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -12,9 +12,11 @@
     "/components/header/header.css": "/components/header/header.css",
     "/components/footer/footer.css": "/components/footer/footer.css",
     "/components/card/card.css": "/components/card/card.css",
+    "/components/button/button.css": "/components/button/button.css",
     "/components/breadcrumbs/breadcrumbs.css": "/components/breadcrumbs/breadcrumbs.css",
     "/components/alert/alert.css": "/components/alert/alert.css",
     "/components/alert_banner/alert_banner.css": "/components/alert_banner/alert_banner.css",
+    "/components/accordion/accordion.css": "/components/accordion/accordion.css",
     "/dist/css/search-results.css": "/dist/css/search-results.css",
     "/dist/css/progress.css": "/dist/css/progress.css",
     "/dist/css/placeholders.css": "/dist/css/placeholders.css",
@@ -32,6 +34,5 @@
     "/dist/js/bootstrap.min.js": "/dist/js/bootstrap.min.js",
     "/dist/js/bootstrap.min.js.map": "/dist/js/bootstrap.min.js.map",
     "/dist/js/popper.min.js": "/dist/js/popper.min.js",
-    "/dist/js/popper.min.js.map": "/dist/js/popper.min.js.map",
-    "/components/button/button.css": "/components/button/button.css"
+    "/dist/js/popper.min.js.map": "/dist/js/popper.min.js.map"
 }

--- a/psulib_base.libraries.yml
+++ b/psulib_base.libraries.yml
@@ -50,11 +50,6 @@ alert:
     component:
       dist/css/alert.css: {}
 
-accordion:
-  css:
-    component:
-      dist/css/accordion.css: {}
-
 carousel:
   css:
     component:

--- a/scss/components/accordion.scss
+++ b/scss/components/accordion.scss
@@ -1,9 +1,0 @@
-// Generate styles for pagination.
-@import '../init';
-
-// Override variables here:
-
-// Import bootstrap pagination styles.
-@import 'bootstrap/scss/accordion';
-
-// Custom styles go here.


### PR DESCRIPTION
<img width="1364" alt="Screenshot 2024-08-02 at 12 55 23 PM" src="https://github.com/user-attachments/assets/5cb8d9e1-4807-4d3d-b78f-b95e72598256">

This is related to https://github.com/psu-libraries/psul-web/tree/549-remove-accordion-component-from-psul_theme which removes the accordion styles from the sub theme and updates implementations of this on lib guides page.