### PR TITLE
Issue #147 - Decreasing font-size of breadcrumb.

### DIFF
--- a/components/breadcrumbs/breadcrumbs.scss
+++ b/components/breadcrumbs/breadcrumbs.scss
@@ -4,5 +4,6 @@
 @import "~bootstrap/scss/breadcrumb";
 
 li.breadcrumb-item {
-    font-family: $font-family-condensed;
+  font-family: $font-family-condensed;
+  font-size: $font-size-sm;
 }


### PR DESCRIPTION
Decrease the font-size on breadcrumbs to $font-size-sm.

<img width="766" alt="Screenshot 2024-08-12 at 12 10 41 PM" src="https://github.com/user-attachments/assets/103ccd80-2389-494e-b322-0f85b949ea59">
