### PR TITLE
150 dropdown menu does not work with the base theme alone

### DIFF
--- a/components/header/header.js
+++ b/components/header/header.js
@@ -58,9 +58,9 @@
         navElement.querySelectorAll('.nav-item.show').forEach(closeDropdown);
       }
 
-
-      once('psul-theme-mainMenuNav', '#mainMenuNav', context).forEach(() => {
-        document.querySelectorAll('#mainMenuNav').forEach(setupDropdownBehavior);
+      // Keeping the #mainMenuNav id to support psul_theme template.
+      once('psul-theme-mainMenuNav', '#mainMenuNav, .main-menu-nav', context).forEach(() => {
+        document.querySelectorAll('#mainMenuNav, .main-menu-nav').forEach(setupDropdownBehavior);
       });
 
       once('psul-theme-offcanvasMain', '#offcanvasMain', context).forEach(() => {

--- a/templates/navigation/menu--main.html.twig
+++ b/templates/navigation/menu--main.html.twig
@@ -19,27 +19,26 @@
  */
 #}
 {% import _self as menus %}
-
 {#
 We call a macro which calls itself to render the full tree.
 @see http://twig.sensiolabs.org/doc/tags/macro.html
 #}
-{{ menus.build_menu(items, attributes, 0) }}
+{{ menus.build_menu(items, attributes.addClass('main-menu'), 0) }}
 
 {% macro build_menu(items, attributes, menu_level) %}
   {% import _self as menus %}
   {% if items %}
     {%
       set ul_classes = [
-        menu_level == 0 ? 'navbar-nav justify-content-end flex-wrap',
-        menu_level > 0 ? 'dropdown-menu',
-        'nav-level-' ~ menu_level,
-      ]
+      menu_level == 0 ? 'navbar-nav justify-content-end flex-wrap main-menu main-menu-nav' : '',
+      menu_level > 0 ? 'dropdown-menu' : '',
+      'nav-level-' ~ menu_level,
+    ]
     %}
     <ul{{ attributes.addClass(ul_classes) }}>
-    {% for item in items %}
-      {{ menus.add_link(item, attributes.removeClass(ul_classes), menu_level) }}
-    {% endfor %}
+      {% for item in items %}
+        {{ menus.add_link(item, attributes.removeClass(ul_classes), menu_level) }}
+      {% endfor %}
     </ul>
   {% endif %}
 {% endmacro %}
@@ -49,24 +48,27 @@ We call a macro which calls itself to render the full tree.
   {%
     set list_item_classes = [
     'nav-item',
-    item.is_expanded ? 'dropdown'
+    item.is_expanded ? 'dropdown' : ''
   ]
   %}
   {%
     set link_class = [
-      menu_level == 0 ? 'nav-link',
-      item.in_active_trail ? 'active',
-      menu_level == 0 and (item.is_expanded or item.is_collapsed) ? 'dropdown-toggle',
-      menu_level > 0 ? 'dropdown-item',
-    ]
-  %}
-  {%
-    set toggle_class = [
-    ]
+    menu_level == 0 ? 'nav-link' : '',
+    item.in_active_trail ? 'active' : '',
+    menu_level == 0 and (item.is_expanded or item.is_collapsed) ? 'dropdown-toggle' : '',
+    menu_level > 0 ? 'dropdown-item' : '',
+  ]
   %}
   <li{{ item.attributes.addClass(list_item_classes) }}>
     {% if menu_level == 0 and item.below %}
-      {{ link(item.title, item.url, { 'class': link_class, 'role': 'button', 'data-bs-toggle': 'dropdown', 'aria-expanded': 'false', 'title': ('Expand menu' | t) ~ ' ' ~ item.title }) }}
+      <div class="link-container">
+        {{ link(item.title, item.url, { 'class': link_class, 'role': 'button', 'aria-expanded': item.in_active_trail ? 'true' : 'false', 'title': ('Expand menu' | t) ~ ' ' ~ item.title }) }}
+        <span class="dropdown-arrow">
+          <svg role="button" aria-expanded="{% if item.in_active_trail %}true{% else %}false{% endif %}" width="16" height="16" viewBox="0 0 14 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M7.00777 8.33901C6.84851 8.33901 6.69921 8.31413 6.55986 8.26436C6.42051 8.21459 6.29112 8.12999 6.17168 8.01055L0.647497 2.48637C0.42852 2.26739 0.324009 1.99367 0.333962 1.66521C0.343916 1.33674 0.458381 1.06302 0.677357 0.844044C0.896334 0.625068 1.17503 0.515579 1.51345 0.515579C1.85187 0.515579 2.13057 0.625068 2.34954 0.844044L7.00777 5.50227L11.6959 0.814184C11.9148 0.595207 12.1886 0.490696 12.517 0.500649C12.8455 0.510603 13.1192 0.625068 13.3382 0.844044C13.5572 1.06302 13.6666 1.34172 13.6666 1.68014C13.6666 2.01855 13.5572 2.29725 13.3382 2.51623L7.84386 8.01055C7.72442 8.12999 7.59503 8.21459 7.45568 8.26436C7.31633 8.31413 7.16703 8.33901 7.00777 8.33901Z" fill="currentColor"/>
+          </svg>
+        </span>
+      </div>
       {{ menus.build_menu(item.below, attributes, menu_level + 1) }}
     {% else %}
       {{ link(item.title, item.url, { 'class': link_class }) }}


### PR DESCRIPTION
… with class.

There should be no visual change on this.  Porting https://github.com/psu-libraries/psul-web/blob/main/web/themes/custom/psul_theme/templates/navigation/menu--main.html.twig into the base theme.  Adjusted javascript to handle a class or an id for the main menu.

This should probably be included in component.