### PR TITLE
Issue #136 - Porting contact card component from psul_theme.

### DIFF
--- a/components/contact_card/README.md
+++ b/components/contact_card/README.md
@@ -1,0 +1,23 @@
+# Contact card
+
+Add a contact card for displaying people, and departments contact info.
+
+## Usage
+
+Add this to a display template.
+
+```twig
+  {% include 'psulib_base:contact_card' with {
+    title: label|render|striptags|trim,
+    title_url: url,
+    subtitle: '',
+    address: content.field_psofficeaddress,
+    phones: [
+      content.field_general_phone|render|striptags|trim
+    ],
+    fax: content.field_fax_number|render|striptags|trim,
+    email:  content.field_email|render|striptags|trim,
+    website: '',
+    stacked: false
+  } %}
+```

--- a/components/contact_card/contact_card.component.yml
+++ b/components/contact_card/contact_card.component.yml
@@ -1,0 +1,54 @@
+'$schema': 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: Contact Card
+status: stable
+description: Display contact information for organizations and people.
+props:
+  type: object
+  properties:
+    title:
+      type: string
+      title: Title
+    title_url:
+      type: string
+      title: URL to make the title a link.
+    subtitle:
+      type: string
+      title: Subtitle
+    address:
+      type: string
+      title: Address
+    phones:
+      type: array
+      title: Phones
+      description: Array of phone numbers
+      items:
+        type: string
+    fax:
+      type: string
+      title: Fax Number
+    email:
+      type: string
+      title: Email
+    website:
+      type: string
+      title: Address
+    cta_button:
+      type: object
+      title: CTA Button
+      properties:
+        title:
+          type: string
+          title: Button Title
+        url:
+          type: string
+          title: Button URL
+    stacked:
+      type: boolean
+      title: Stacked Display with contact details in 2 rows.
+      default: false
+    attributes:
+      type: Drupal\Core\Template\Attribute
+    utility_classes:
+      type: array
+      items:
+        type: string

--- a/components/contact_card/contact_card.scss
+++ b/components/contact_card/contact_card.scss
@@ -1,0 +1,65 @@
+@use "sass:map";
+@import '../../scss/init';
+
+@mixin container-breakpoint($name, $container: "contact-card", $breakpoints: $grid-breakpoints) {
+  $min: breakpoint-min($name, $breakpoints);
+  @if $min {
+    @container contact-card (min-width: $min) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
+.contact-card {
+  display: flex;
+  flex-direction: column;
+  gap: $spacer * .75;
+  box-shadow: $box-shadow;
+  padding: $spacer * 1.25;
+  background-color: $white;
+  @include make-link($link-color, none, $link-hover-color, underline);
+  container: contact-card / inline-size;
+
+  i {
+    margin-right: $spacer * .5;
+  }
+
+  &--address {
+    font-style: italic;
+  }
+
+  &--header--title {
+    font-size: $font-size-base * 1.125;
+    margin-bottom: 0;
+    font-weight: bold;
+  }
+
+  &--body {
+    display: flex;
+    gap: $spacer * .75;
+    flex-direction: column;
+  }
+
+  &--contacts--email {
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+    text-wrap: nowrap;
+  }
+
+  // Adding stacked card variations.
+  &.contact-card__stacked {
+    // Need to use the #{...} format to get the map-get to actually work.
+    @container contact-card (min-width: #{map-get($grid-breakpoints, "md")}) {
+      .contact-card--body {
+        flex-direction: row;
+
+        > div {
+          width: 50%;
+        }
+      }
+    }
+  }
+
+}

--- a/components/contact_card/contact_card.twig
+++ b/components/contact_card/contact_card.twig
@@ -1,0 +1,76 @@
+{% set attributes = attributes ?: create_attribute() %}
+
+{%
+  set classes = [
+    'contact-card',
+    stacked ? 'contact-card__stacked',
+  ]|merge(utility_classes ?: [])
+%}
+
+<div {{ attributes.addClass(classes) }}>
+  <div class="contact-card--header">
+    {%
+      include 'psulib_base:heading' with {
+        heading_html_tag: 'h3',
+        title_link: title_url ?? '',
+        content: title,
+        heading_utility_classes: [
+          'contact-card--header--title',
+        ],
+      }
+    %}
+    {% if subtitle %}<span class="contact-card--header--subtitle">{{ subtitle }}</span>{% endif %}
+  </div>
+
+  <div class="contact-card--body">
+    {% if address %}<div class="contact-card--address"><em>{{ address }}</em></div>{% endif %}
+
+    <div class="contact-card--contacts">
+      {% for phone in phones %}
+        {% if phone %}
+          <div class="contact-card--contacts--phone">
+            <i class="bi bi-telephone-fill"></i>
+            <a href="tel:+{{ phone }}" >{{ phone }}</a>
+          </div>
+        {% endif %}
+      {% endfor %}
+
+      {% if email %}
+        <div class="contact-card--contacts--email">
+          <i class="bi bi-envelope-fill"></i>
+          <a href="mailto:{{ email }}" >{{ email }}</a>
+        </div>
+      {% endif %}
+
+      {% if fax %}
+        <div class="contact-card--contacts--fax">
+          <i class="bi bi-printer-fill"></i>
+          <a href="fax:+{{ fax }}" >{{ fax }}</a>
+        </div>
+      {% endif %}
+
+      {% if website %}
+        <div class="contact-card--contacts--website">
+          <i class="bi bi-box-arrow-up-right"></i>
+          <a href="{{ website }}" >{{ website }}</a>
+        </div>
+      {% endif %}
+    </div>
+
+  </div>
+  {% if cta_button %}
+      {% if cta_button_render|render %}
+        {{ cta_button_render }}
+      {% elseif cta_button %}
+        {%
+          include 'psulib_base:button' with {
+            button_html_tag: 'a',
+            url: cta_button.url,
+            color: 'primary',
+            content: cta_button.title,
+            button_utility_classes: [],
+          }
+        %}
+      {% endif %}
+  {% endif %}
+</div>

--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -14,6 +14,7 @@
     "/components/image/image.css": "/components/image/image.css",
     "/components/header/header.css": "/components/header/header.css",
     "/components/footer/footer.css": "/components/footer/footer.css",
+    "/components/contact_card/contact_card.css": "/components/contact_card/contact_card.css",
     "/components/card/card.css": "/components/card/card.css",
     "/components/button/button.css": "/components/button/button.css",
     "/components/breadcrumbs/breadcrumbs.css": "/components/breadcrumbs/breadcrumbs.css",


### PR DESCRIPTION
This can be tested by replacing `psul_theme:contact_card` with `psulib_base:contact_card` in `/psul_theme/templates/content/node--department--contact.html.twig` and `/psul_theme/templates/content/node--library--contact.html.twig`. This should have no visual changes.