### PR TITLE
Issue #174 - Replacing footer element with a div. Adding minimal styl…

### DIFF
--- a/scss/base/_node.scss
+++ b/scss/base/_node.scss
@@ -4,5 +4,18 @@
  */
 
 .node--unpublished {
-    background-color: #fef6f8;
+  background-color:  #fef6f8;
+}
+
+.node__meta {
+  font-size: $font-size-sm;
+  color: $valchar-grey;
+  border-top: 1px solid $border-color;
+  padding-top: calc($spacer /2 );
+  margin: $spacer 0;
+
+  @include media-breakpoint-up(md) {
+    // Preventing border from going full width.
+    margin-right: calc(100% - 500px);
+  }
 }

--- a/templates/content/node.html.twig
+++ b/templates/content/node.html.twig
@@ -88,13 +88,13 @@
   {{ title_suffix }}
 
   {% if display_submitted %}
-    <footer class="node__meta">
-      {{ author_picture }}
+
+    <div class="node__meta">
       <div{{ author_attributes.addClass('node__submitted') }}>
         {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
         {{ metadata }}
       </div>
-    </footer>
+    </div>
   {% endif %}
 
   <div{{ content_attributes.addClass('node__content') }}>


### PR DESCRIPTION
…es to for node meta.  Removing profile image.

<img width="696" alt="Screenshot 2024-09-25 at 9 05 23 AM" src="https://github.com/user-attachments/assets/4e002ec9-e3a8-4939-883b-355a04d3a784">

To test this you will need to enable `Display author and date information` on a content type.  For example in psul-web
- Show author info on Building https://psul-web.psul.localhost/admin/structure/types/manage/building
- Go to https://psul-web.psul.localhost/library and you will see the display.