### PR TITLE
217 update preloaded fonts

### DIFF
--- a/assets/fonts/fonts.css
+++ b/assets/fonts/fonts.css
@@ -174,17 +174,6 @@
         url('./Roboto_Condensed/RobotoCondensed-VariableFont_wght.ttf') format('truetype'),
 }
 
-@font-face {
-    font-family: 'Roboto Condensed';
-    font-style: italic;
-    font-weight: 100 900;
-    font-display: swap;
-    src:
-        local('Roboto Condensed Italic'),
-        url('./Roboto_Condensed/RobotoCondensed-Italic-VariableFont_wght.woff2') format('woff2'),
-        url('./Roboto_Condensed/RobotoCondensed-Italic-VariableFont_wght.ttf') format('truetype'),
-}
-
 /**
  * Roboto Slab Fonts Definitions
  * @see https://fonts.google.com/specimen/Roboto+Condensed?query=roboto+cond

--- a/psulib_base.theme
+++ b/psulib_base.theme
@@ -36,9 +36,17 @@ function psulib_base_page_attachments_alter(array &$attachments) {
   $theme_path = \Drupal::service('extension.list.theme')->getPath('psulib_base');
 
   $files = [
+    // Roboto is the default font.
     base_path() . $theme_path . '/assets/fonts/Roboto/roboto-regular-webfont.woff2',
+    base_path() . $theme_path . '/assets/fonts/Roboto/roboto-bold-webfont.woff2',
+    base_path() . $theme_path . '/assets/fonts/Roboto/roboto-italic-webfont.woff2',
+
+    // Roboto Slab is used for <h1> elements.
     base_path() . $theme_path . '/assets/fonts/Roboto_Slab/static/RobotoSlab-Bold.woff2',
+
+    // Roboto Condensed used for navigation elements (menus and breadcrumbs).
     base_path() . $theme_path . '/assets/fonts/Roboto_Condensed/RobotoCondensed-VariableFont_wght.woff2',
+
   ];
 
   foreach ($files as $path) {


### PR DESCRIPTION
## Changes
- Documenting why font files are preloaded
- Preloading bold and italic font files (since they are used on almost every page)
- Removing `RobotoCondensed-Italic-VariableFont_wght.woff2` since we're not italicizing any menu links and the italic seem to work without the separate file.   This was being unnecessarily loaded on every single page.

<img width="1039" alt="Screenshot 2024-12-16 at 2 58 09 PM" src="https://github.com/user-attachments/assets/3d0f3bb7-1370-4d0e-8f97-a112b3dfbc55" />
