### PR TITLE
Issue #223 - Explicitly setting display on accordion buttons to flex.

### DIFF
--- a/components/accordion/accordion.scss
+++ b/components/accordion/accordion.scss
@@ -17,6 +17,7 @@
       background-color: $pa-limestone-max-light;
       color: $primary;
       border: 0;
+      display: flex;
 
       .accordion-header {
         font-size: 1.1rem;


### PR DESCRIPTION
After adding the flex display the accordion button looks correct again:

<img width="1033" alt="Screenshot 2025-01-08 at 10 13 48 AM" src="https://github.com/user-attachments/assets/5072464b-fb9b-428b-a8d4-41373a0db7f7" />
