### PR TITLE
232 add full bleed styles to allow background colors

### DIFF
--- a/components/content_with_toc/content_with_toc.twig
+++ b/components/content_with_toc/content_with_toc.twig
@@ -39,5 +39,6 @@
         {% endfor %}
         </div>
       </div>
+    </div>
   </div>
 {% endif %}

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -1,6 +1,7 @@
 // General Drupal styles.
 @import './base/admin';
 @import './base/forms';
+@import './base/full_bleed';
 @import './base/webform';
 @import './base/indent';
 @import './base/layout';

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -23,3 +23,13 @@
   font-family: "bootstrap-icons";
   vertical-align: bottom;
 }
+
+@mixin light-text {
+  color: #fff;
+  --bs-body-color: #{$white-out};
+  --bs-heading-color: #{$white-out};
+  --bs-link-color: #{$pa-link-light};
+  --bs-link-color-rgb: #{$pa-link-light};
+  --bs-link-hover-color: #{$white-out};
+  --bs-link-hover-color-rgb: #{$white-out};
+}

--- a/scss/base/_full_bleed.scss
+++ b/scss/base/_full_bleed.scss
@@ -15,3 +15,8 @@
 .full-bleed--limestone-light {
   --full-bleed-bg-color: #{$pa-limestone-max-light};
 }
+
+.full-bleed--navy {
+  @include light-text;
+  --full-bleed-bg-color: #{$nittany-navy};
+}

--- a/scss/base/_full_bleed.scss
+++ b/scss/base/_full_bleed.scss
@@ -1,0 +1,17 @@
+.full-bleed {
+  // Setting this to transparent so it does nohthing unless a color is set.
+  --full-bleed-bg-color: transparent;
+
+  box-shadow: 0 0 0 100vmax var(--full-bleed-bg-color);
+  clip-path: inset(0 -100vmax);
+  background-color: var(--full-bleed-bg-color);
+  padding: $spacer;
+}
+
+.full-bleed--slate-light {
+  --full-bleed-bg-color: #{$pa-slate-max-light};
+}
+
+.full-bleed--limestone-light {
+  --full-bleed-bg-color: #{$pa-limestone-max-light};
+}


### PR DESCRIPTION
Adding some basic styles to add full width background colors.  These should only be used on pages without sidebars.

The following classes can be added to divs to add the background color.

`full-bleed full-bleed--limestone-light`
`full-bleed full-bleed--slate-light`

<img width="842" alt="Screenshot 2025-02-04 at 2 24 47 PM" src="https://github.com/user-attachments/assets/a3bc50a1-4c12-4e80-aa6d-ff9a02ecfc46" />
<img width="956" alt="Screenshot 2025-02-04 at 2 24 37 PM" src="https://github.com/user-attachments/assets/7f2f32a8-9423-463f-a668-4bf6597e9654" />
