### PR TITLE
237 add directory display variant to contact card

### DIFF
--- a/components/contact_card/contact_card.component.yml
+++ b/components/contact_card/contact_card.component.yml
@@ -46,6 +46,10 @@ props:
       type: 'boolean'
       title: Stacked Display with contact details in 2 rows.
       default: false
+    linked_card:
+      type: 'boolean'
+      title: Make the entire card link to the title_url.
+      default: false
     attributes:
       type: 'Drupal\Core\Template\Attribute'
     utility_classes:

--- a/components/contact_card/contact_card.component.yml
+++ b/components/contact_card/contact_card.component.yml
@@ -56,3 +56,17 @@ props:
       type: 'array'
       items:
         type: 'string'
+    image:
+      type: 'string'
+      title: Image Media
+    image_src:
+      type: 'string'
+      title: Image Source URL
+    display_image:
+      type: 'boolean'
+      title: Display the Image
+      default: false
+slots:
+  image_block:
+    title: Card Image
+    description: Slot for the image on the left of the card.

--- a/components/contact_card/contact_card.component.yml
+++ b/components/contact_card/contact_card.component.yml
@@ -50,7 +50,7 @@ props:
       type: 'boolean'
       title: Make the entire card link to the title_url.
       default: false
-    attributes:
+    contact_card_attributes:
       type: 'Drupal\Core\Template\Attribute'
     utility_classes:
       type: 'array'

--- a/components/contact_card/contact_card.scss
+++ b/components/contact_card/contact_card.scss
@@ -92,8 +92,7 @@
         flex-direction: row;
 
         > div {
-          max-width: 50%;
-          flex-grow: 1;
+          width: 50%;
         }
       }
     }
@@ -102,8 +101,7 @@
   &.contact-card__linked-card {
     transition: $input-transition;
 
-    &:hover,
-    &:has(.stretched-link:hover) {
+    &:hover {
       box-shadow: 0 .5rem 1rem rgba($black, .4);
       border: 1px solid $nittany-navy;
 

--- a/components/contact_card/contact_card.scss
+++ b/components/contact_card/contact_card.scss
@@ -18,6 +18,7 @@
   gap: $spacer * .75;
   box-shadow: $box-shadow;
   padding: $spacer * 1.25;
+  border: 1px solid transparent;
   background-color: $white;
   @include make-link($link-color, none, $link-hover-color, underline);
   container: contact-card / inline-size;
@@ -48,6 +49,10 @@
     text-wrap: nowrap;
   }
 
+  &--chevron {
+    display: none;
+  }
+
   // Adding stacked card variations.
   &.contact-card__stacked {
     // Need to use the #{...} format to get the map-get to actually work.
@@ -62,4 +67,34 @@
     }
   }
 
+  &.contact-card__linked-card {
+    transition: $input-transition;
+
+    &:hover,
+    &:has(.stretched-link:hover) {
+      box-shadow: 0 .5rem 1rem rgba($black, .4);
+      border: 1px solid $nittany-navy;
+
+      .contact-card--chevron svg {
+        fill: $nittany-navy !important;
+      }
+    }
+
+    .contact-card--chevron {
+      display: block;
+      position: absolute;
+      right: $spacer / 2;
+      top: calc(50% - 25px);
+      width: 25px;
+      svg {
+        fill: $link-color;
+      }
+    }
+
+    .contact-card--contacts {
+      z-index: 2;
+      position: relative;
+      margin-right: $spacer / 2;
+    }
+  }
 }

--- a/components/contact_card/contact_card.scss
+++ b/components/contact_card/contact_card.scss
@@ -27,6 +27,37 @@
     margin-right: $spacer * .5;
   }
 
+  &--image,
+  &--chevron {
+    display: none;
+  }
+
+  &--wrapper {
+    display: flex;
+    flex-direction: row;
+    gap: $spacer;
+
+    @container contact-card (min-width: #{map-get($grid-breakpoints, "md")}) {
+      .contact-card--image {
+        flex-grow: 0;
+        flex-shrink: 0;
+        display: block;
+        width: 132px;
+      }
+    }
+
+    .content-card--main {
+      flex-grow: 1;
+    }
+
+    .contact-card--chevron {
+      flex-grow: 0;
+      flex-shrink: 0;
+      width: 25px;
+      align-content: center;
+    }
+  }
+
   &--address {
     font-style: italic;
   }
@@ -61,7 +92,8 @@
         flex-direction: row;
 
         > div {
-          width: 50%;
+          max-width: 50%;
+          flex-grow: 1;
         }
       }
     }
@@ -82,10 +114,6 @@
 
     .contact-card--chevron {
       display: block;
-      position: absolute;
-      right: $spacer / 2;
-      top: calc(50% - 25px);
-      width: 25px;
       svg {
         fill: $link-color;
       }

--- a/components/contact_card/contact_card.twig
+++ b/components/contact_card/contact_card.twig
@@ -9,79 +9,108 @@
 %}
 
 <div {{ attributes.addClass(classes) }}>
-  <div class="contact-card--header">
-    {%
-      include 'psulib_base:heading' with {
-        heading_html_tag: 'h3',
-        title_link: title_url ?? '',
-        content: title,
-        heading_utility_classes: [
-          'contact-card--header--title',
-        ],
-        heading_link_utility_classes: [
-          linked_card ? 'stretched-link',
-        ],
-      }
-    %}
-    {% if subtitle %}<span class="contact-card--header--subtitle">{{ subtitle }}</span>{% endif %}
-  </div>
+  <div class="contact-card--wrapper">
 
-  <div class="contact-card--body">
-    {% if address %}<div class="contact-card--address"><em>{{ address }}</em></div>{% endif %}
+    {% block image_block %}
+      {% if display_image and (image or image_src) %}
+        <div class="contact-card--image">
 
-    <div class="contact-card--contacts">
-      {% for phone in phones %}
-        {% if phone %}
-          <div class="contact-card--contacts--phone">
-            <i class="bi bi-telephone-fill"></i>
-            <a href="tel:+{{ phone }}" >{{ phone }}</a>
-          </div>
-        {% endif %}
-      {% endfor %}
-
-      {% if email %}
-        <div class="contact-card--contacts--email">
-          <i class="bi bi-envelope-fill"></i>
-          <a href="mailto:{{ email }}" >{{ email }}</a>
+          {% if image %}
+            {{ image }}
+          {% elseif image_src %}
+            {# @todo convert to use psulib_base:image #}
+            <img src="{{ image_src }}" class="img-fluid"/>
+          {% endif %}
         </div>
       {% endif %}
+    {% endblock %}
 
-      {% if fax %}
-        <div class="contact-card--contacts--fax">
-          <i class="bi bi-printer-fill"></i>
-          <a href="fax:+{{ fax }}" >{{ fax }}</a>
-        </div>
-      {% endif %}
-
-      {% if website %}
-        <div class="contact-card--contacts--website">
-          <i class="bi bi-box-arrow-up-right"></i>
-          <a href="{{ website }}" >{{ website }}</a>
-        </div>
-      {% endif %}
-    </div>
-  </div>
-
-  {% if cta_button %}
-      {% if cta_button_render|render %}
-        {{ cta_button_render }}
-      {% elseif cta_button %}
+    <div class="content-card--main">
+      <div class="contact-card--header">
         {%
-          include 'psulib_base:button' with {
-            button_html_tag: 'a',
-            url: cta_button.url,
-            color: 'primary',
-            content: cta_button.title,
-            button_utility_classes: [],
+          include 'psulib_base:heading' with {
+            heading_html_tag: 'h3',
+            title_link: title_url ?? '',
+            content: title,
+            heading_utility_classes: [
+              'contact-card--header--title',
+            ],
+            heading_link_utility_classes: [
+              linked_card ? 'stretched-link',
+            ],
           }
         %}
-      {% endif %}
-  {% endif %}
+        {% if subtitle %}
+          <span class="contact-card--header--subtitle">{{ subtitle }}</span>
+        {% endif %}
+      </div>
 
-  {% if linked_card and stacked %}
-    <div class="contact-card--chevron">
-      <svg role="img" aria-labelledby="Icon-chevronRight-:r4b:" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="css-gd4dzf"><title id="Icon-chevronRight-:r4b:">chevronRight icon</title><path d="M6.49327 21.5067C6.16442 21.1779 6 20.7593 6 20.2511C6 19.7429 6.16442 19.3244 6.49327 18.9955L13.4888 12L6.49327 5.00448C6.16442 4.67564 6 4.2571 6 3.74888C6 3.24066 6.16442 2.82212 6.49327 2.49327C6.82212 2.16442 7.24066 2 7.74888 2C8.2571 2 8.67564 2.16442 9.00448 2.49327L17.2556 10.7444C17.435 10.9238 17.562 11.1181 17.6368 11.3274C17.7115 11.5366 17.7489 11.7608 17.7489 12C17.7489 12.2392 17.7115 12.4634 17.6368 12.6726C17.562 12.8819 17.435 13.0762 17.2556 13.2556L9.00448 21.5067C8.67564 21.8356 8.2571 22 7.74888 22C7.24066 22 6.82212 21.8356 6.49327 21.5067Z"></path></svg>
+      <div class="contact-card--body">
+
+        {% if address %}
+          <div class="contact-card--address">
+            <em>{{ address }}</em>
+          </div>
+        {% endif %}
+
+        <div class="contact-card--contacts">
+          {% for phone in phones %}
+            {% if phone %}
+              <div class="contact-card--contacts--phone">
+                <i class="bi bi-telephone-fill"></i>
+                <a href="tel:+{{ phone }}">{{ phone }}</a>
+              </div>
+            {% endif %}
+          {% endfor %}
+
+          {% if email %}
+            <div class="contact-card--contacts--email">
+              <i class="bi bi-envelope-fill"></i>
+              <a href="mailto:{{ email }}">{{ email }}</a>
+            </div>
+          {% endif %}
+
+          {% if fax %}
+            <div class="contact-card--contacts--fax">
+              <i class="bi bi-printer-fill"></i>
+              <a href="fax:+{{ fax }}">{{ fax }}</a>
+            </div>
+          {% endif %}
+
+          {% if website %}
+            <div class="contact-card--contacts--website">
+              <i class="bi bi-box-arrow-up-right"></i>
+              <a href="{{ website }}">{{ website }}</a>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+      {% if cta_button %}
+        {% if cta_button_render|render %}
+          {{ cta_button_render }}
+        {% elseif cta_button %}
+          {%
+              include 'psulib_base:button' with {
+                button_html_tag: 'a',
+                url: cta_button.url,
+                color: 'primary',
+                content: cta_button.title,
+                button_utility_classes: [],
+              }
+            %}
+        {% endif %}
+      {% endif %}
     </div>
-  {% endif %}
+
+
+    {% if linked_card %}
+      <div class="contact-card--chevron">
+        <svg role="img" aria-labelledby="Icon-chevronRight-:r4b:" viewbox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="css-gd4dzf">
+          <title id="Icon-chevronRight-:r4b:">chevronRight icon</title>
+          <path d="M6.49327 21.5067C6.16442 21.1779 6 20.7593 6 20.2511C6 19.7429 6.16442 19.3244 6.49327 18.9955L13.4888 12L6.49327 5.00448C6.16442 4.67564 6 4.2571 6 3.74888C6 3.24066 6.16442 2.82212 6.49327 2.49327C6.82212 2.16442 7.24066 2 7.74888 2C8.2571 2 8.67564 2.16442 9.00448 2.49327L17.2556 10.7444C17.435 10.9238 17.562 11.1181 17.6368 11.3274C17.7115 11.5366 17.7489 11.7608 17.7489 12C17.7489 12.2392 17.7115 12.4634 17.6368 12.6726C17.562 12.8819 17.435 13.0762 17.2556 13.2556L9.00448 21.5067C8.67564 21.8356 8.2571 22 7.74888 22C7.24066 22 6.82212 21.8356 6.49327 21.5067Z"></path>
+        </svg>
+      </div>
+    {% endif %}
+  </div>
 
 </div>

--- a/components/contact_card/contact_card.twig
+++ b/components/contact_card/contact_card.twig
@@ -4,6 +4,7 @@
   set classes = [
     'contact-card',
     stacked ? 'contact-card__stacked',
+    linked_card ? 'contact-card__linked-card',
   ]|merge(utility_classes ?: [])
 %}
 
@@ -16,6 +17,9 @@
         content: title,
         heading_utility_classes: [
           'contact-card--header--title',
+        ],
+        heading_link_utility_classes: [
+          linked_card ? 'stretched-link',
         ],
       }
     %}
@@ -56,8 +60,8 @@
         </div>
       {% endif %}
     </div>
-
   </div>
+
   {% if cta_button %}
       {% if cta_button_render|render %}
         {{ cta_button_render }}
@@ -73,4 +77,11 @@
         %}
       {% endif %}
   {% endif %}
+
+  {% if linked_card and stacked %}
+    <div class="contact-card--chevron">
+      <svg role="img" aria-labelledby="Icon-chevronRight-:r4b:" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="css-gd4dzf"><title id="Icon-chevronRight-:r4b:">chevronRight icon</title><path d="M6.49327 21.5067C6.16442 21.1779 6 20.7593 6 20.2511C6 19.7429 6.16442 19.3244 6.49327 18.9955L13.4888 12L6.49327 5.00448C6.16442 4.67564 6 4.2571 6 3.74888C6 3.24066 6.16442 2.82212 6.49327 2.49327C6.82212 2.16442 7.24066 2 7.74888 2C8.2571 2 8.67564 2.16442 9.00448 2.49327L17.2556 10.7444C17.435 10.9238 17.562 11.1181 17.6368 11.3274C17.7115 11.5366 17.7489 11.7608 17.7489 12C17.7489 12.2392 17.7115 12.4634 17.6368 12.6726C17.562 12.8819 17.435 13.0762 17.2556 13.2556L9.00448 21.5067C8.67564 21.8356 8.2571 22 7.74888 22C7.24066 22 6.82212 21.8356 6.49327 21.5067Z"></path></svg>
+    </div>
+  {% endif %}
+
 </div>

--- a/components/contact_card/contact_card.twig
+++ b/components/contact_card/contact_card.twig
@@ -1,14 +1,14 @@
-{% set attributes = attributes ?: create_attribute() %}
+{% set contact_card_attributes = contact_card_attributes ?: create_attribute() %}
 
 {%
   set classes = [
     'contact-card',
-    stacked ? 'contact-card__stacked',
-    linked_card ? 'contact-card__linked-card',
+    stacked ? 'contact-card__stacked' : '',
+    linked_card ? 'contact-card__linked-card position-relative': '',
   ]|merge(utility_classes ?: [])
 %}
 
-<div {{ attributes.addClass(classes) }}>
+<div {{ contact_card_attributes.addClass(classes) }}>
   <div class="contact-card--wrapper">
 
     {% block image_block %}
@@ -19,7 +19,7 @@
             {{ image }}
           {% elseif image_src %}
             {# @todo convert to use psulib_base:image #}
-            <img src="{{ image_src }}" class="img-fluid"/>
+            <img src="{{ image_src }}" class="img-fluid" />
           {% endif %}
         </div>
       {% endif %}


### PR DESCRIPTION
Reworked the contact card component so i can be used on the directory page.

## Changes
- Add wrapper to the contact card so we can cleanly handle images and the chevron with stacked functionality. You can see different flex layouts below.
<img width="1004" alt="Screenshot 2025-02-05 at 3 07 20 PM" src="https://github.com/user-attachments/assets/c78431c5-5c50-417e-a260-51ba9245406f" />
<img width="1001" alt="Screenshot 2025-02-05 at 3 07 27 PM" src="https://github.com/user-attachments/assets/2bc024a2-e9b5-4fb0-b5ad-5bfe8f629272" />

- Added new props to pass in images and linked_card setting.  
- Update and template and styles to make this work.

https://github.com/user-attachments/assets/c40dc02c-703a-431f-b1b4-844a0dc78304

We might need to do additional work with the images.

I tested this on the psul-web site by modifying `node--department--contact.html.twig` template to something like (the last 3 properties are new).  Then moving the Contact block from the sidebar to the main content. 

```twig
  {% include 'psulib_base:contact_card' with {
    title: label,
    title_url: url,
    subtitle: '',
    address: content.field_psofficeaddress,
    phones: [
      content.field_general_phone|render|striptags|trim
    ],
    fax: content.field_fax_number|render|striptags|trim,
    email:  content.field_email|render|striptags|trim,
    website: '',
    stacked: true,
    linked_card: true,
    image_src: 'https://placehold.co/132x156/png',
    display_image: true,
  } %}
```