### PR TITLE
237 add directory display variant to contact card fixes

### DIFF
--- a/components/contact_card/README.md
+++ b/components/contact_card/README.md
@@ -1,23 +1,47 @@
 # Contact card
 
-Add a contact card for displaying people, and departments contact info.
+Add a contact card for displaying people, libraries, and departments contact info.
 
 ## Usage
 
 Add this to a display template.
 
+### Fields Render Arrays (with icon already added)
+
+In some cases the icon and link might be added to fields using a template. In this case we should pass the rendered fields array to the template using a slot.
+
 ```twig
-  {% include 'psulib_base:contact_card' with {
-    title: label|render|striptags|trim,
-    title_url: url,
-    subtitle: '',
-    address: content.field_psofficeaddress,
-    phones: [
-      content.field_general_phone|render|striptags|trim
-    ],
-    fax: content.field_fax_number|render|striptags|trim,
-    email:  content.field_email|render|striptags|trim,
-    website: '',
-    stacked: false
-  } %}
+{% embed 'psulib_base:contact_card' with {
+  title: label,
+  title_url: url,
+  subtitle: '',
+  address: content.field_psofficeaddress,
+  website: '',
+  stacked: true,
+  linked_card: true,
+} %}
+  {% block email %}{{ content.field_email }}{% endblock %}
+  {% block phones %}{{ content.field_general_phone }}{% endblock %}
+  {% block fax %}{{ content.field_fax_number }}{% endblock %}
+{% endembed %}
+```
+
+### Text values for phones and email
+
+You can also pass raw strings to the component and links will be dynamically built.
+
+```twig
+{% include 'psulib_base:contact_card' with {
+  title: 'Mike Henninger',
+  title_url: 'https://github.com/zipymonkey',
+  subtitle: 'Drupal Developer',
+  address: '123 Sesame St',
+  phones: [
+    '603 555-5555'
+  ],
+  fax: '',
+  email: 'msh6004@psu.edu',
+  website: 'https://github.com/zipymonkey',
+  stacked: false
+} %}
 ```

--- a/components/contact_card/contact_card.component.yml
+++ b/components/contact_card/contact_card.component.yml
@@ -67,6 +67,21 @@ props:
       title: Display the Image
       default: false
 slots:
+  address:
+    title: Address
+    description: Slot for the address.
+  email:
+    title: Email
+    description: Slot for the email address.
+  fax:
+    title: Fax
+    description: Slot for the fax number.
   image_block:
     title: Card Image
     description: Slot for the image on the left of the card.
+  phones:
+    title: Phones
+    description: Slot for the phone numbers.
+  website:
+    title: Website
+    description: Slot for the website.

--- a/components/contact_card/contact_card.scss
+++ b/components/contact_card/contact_card.scss
@@ -12,6 +12,10 @@
   }
 }
 
+.contact-card--hide-if-empty:empty {
+  display: none;
+}
+
 .contact-card {
   display: flex;
   flex-direction: column;
@@ -23,7 +27,7 @@
   @include make-link($link-color, none, $link-hover-color, underline);
   container: contact-card / inline-size;
 
-  i {
+  .psul-icon {
     margin-right: $spacer * .5;
   }
 
@@ -48,13 +52,16 @@
 
     .content-card--main {
       flex-grow: 1;
+      width: 100%;
     }
 
-    .contact-card--chevron {
-      flex-grow: 0;
-      flex-shrink: 0;
-      width: 25px;
-      align-content: center;
+    @container contact-card (min-width: #{map-get($grid-breakpoints, "sm")}) {
+      .contact-card--chevron {
+        flex-grow: 0;
+        flex-shrink: 0;
+        width: 25px;
+        align-content: center;
+      }
     }
   }
 
@@ -64,7 +71,7 @@
 
   &--header--title {
     font-size: $font-size-base * 1.125;
-    margin-bottom: 0;
+    margin-bottom: $spacer;
     font-weight: bold;
   }
 
@@ -74,8 +81,8 @@
     flex-direction: column;
   }
 
-  &--contacts--email {
-    overflow-x: hidden;
+  &--contacts > div {
+    overflow-x: clip;
     text-overflow: ellipsis;
     text-wrap: nowrap;
   }

--- a/components/contact_card/contact_card.twig
+++ b/components/contact_card/contact_card.twig
@@ -46,43 +46,59 @@
       </div>
 
       <div class="contact-card--body">
-
-        {% if address %}
-          <div class="contact-card--address">
-            <em>{{ address }}</em>
-          </div>
-        {% endif %}
+        <div class="contact-card--address contact-card--hide-if-empty">
+          {% apply spaceless %}
+            {% block address %}
+              {% if address %}
+                {{ address }}
+              {% endif %}
+            {% endblock %}
+          {% endapply %}
+        </div>
 
         <div class="contact-card--contacts">
-          {% for phone in phones %}
-            {% if phone %}
-              <div class="contact-card--contacts--phone">
-                <i class="bi bi-telephone-fill"></i>
-                <a href="tel:+{{ phone }}">{{ phone }}</a>
+          <div class="contact-card--contacts--phone contact-card--hide-if-empty">
+            {% apply spaceless %}
+              {% block phones %}
+                {% for phone in phones %}
+                  {% if phone %}
+                    {% include 'psulib_base:icon' with {icon: 'phone'} %}
+                    <a href="tel:+{{ phone }}">{{ phone }}</a>
+                  {% endif %}
+                {% endfor %}
+              {% endblock %}
+            {% endapply %}
+          </div>
+
+          <div class="contact-card--contacts--email contact-card--hide-if-empty">
+            {% apply spaceless %}
+              {% block email %}
+                {% if email %}
+                  {% include 'psulib_base:icon' with {icon: 'email'} %}
+                  <a href="mailto:{{ email }}">{{ email }}</a>
+                {% endif %}
+              {% endblock %}
+            {% endapply %}
+          </div>
+          <div class="contact-card--contacts--fax contact-card--hide-if-empty">
+            {% apply spaceless %}
+              {% block fax %}
+                {% if fax %}
+                  {% include 'psulib_base:icon' with {icon: 'fax'} %}
+                  <a href="fax:+{{ fax }}">{{ fax }}</a>
+                {% endif %}
+              {% endblock %}
+            {% endapply %}
+          </div>
+
+          {% block website %}
+            {% if website %}
+              <div class="contact-card--contacts--website">
+                {% include 'psulib_base:icon' with {icon: 'linkOut'} %}
+                <a href="{{ website }}">{{ website }}</a>
               </div>
             {% endif %}
-          {% endfor %}
-
-          {% if email %}
-            <div class="contact-card--contacts--email">
-              <i class="bi bi-envelope-fill"></i>
-              <a href="mailto:{{ email }}">{{ email }}</a>
-            </div>
-          {% endif %}
-
-          {% if fax %}
-            <div class="contact-card--contacts--fax">
-              <i class="bi bi-printer-fill"></i>
-              <a href="fax:+{{ fax }}">{{ fax }}</a>
-            </div>
-          {% endif %}
-
-          {% if website %}
-            <div class="contact-card--contacts--website">
-              <i class="bi bi-box-arrow-up-right"></i>
-              <a href="{{ website }}">{{ website }}</a>
-            </div>
-          {% endif %}
+          {% endblock %}
         </div>
       </div>
       {% if cta_button %}

--- a/psulib_base.theme
+++ b/psulib_base.theme
@@ -197,7 +197,7 @@ function psulib_base_preprocess_media_library_item__widget(array &$variables) {
 }
 
 /**
- * Implements hook_theme_suggestions_HOOK_alter().
+ * Implements hook_theme_suggestions_HOOK_alter() for menu.
  */
 function psulib_base_theme_suggestions_menu_alter(array &$suggestions, array $variables) {
   if (isset($variables['attributes']['data-block']['region'])) {
@@ -205,6 +205,16 @@ function psulib_base_theme_suggestions_menu_alter(array &$suggestions, array $va
     $suggestions[] = $variables['theme_hook_original'] . '__' . $region;
     $suggestions[] = 'menu__' . $region;
   }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for field.
+ *
+ * Adding additional field suggestions.
+ */
+function psulib_base_theme_suggestions_field_alter(array &$suggestions, array $variables) {
+  $suggestions[] = 'field__' . $variables['element']['#entity_type'] . '__' . $variables['element']['#field_name'] . '__' . $variables['element']['#bundle'] . '__view_mode_' . $variables['element']['#view_mode'];
+  $suggestions[] = 'field__' . $variables['element']['#entity_type'] . '__' . $variables['element']['#field_name'] . '__view_mode_' . $variables['element']['#view_mode'];
 }
 
 /**


### PR DESCRIPTION
Refactoring the contact_card component to allow us to pass render arrays for contact information.  This change will likely cause issues with any current implementation of the contact_card (e.g. node--department--contact.html.twig, and node--library-contact.html.twig).

The contact display for departments should be

```twig
  {% embed 'psulib_base:contact_card' with {
    title: label,
    title_url: url,
    subtitle: '',
    address: content.field_psofficeaddress,
    website: '',
    stacked: true,
    linked_card: true,
  } %}
    {% block email %}{{ content.field_email }}{% endblock %}
    {% block phones %}{{ content.field_general_phone }}{% endblock %}
    {% block fax %}{{ content.field_fax_number }}{% endblock %}
  {% endembed %}
```