### PR TITLE
Issue #277 - Adding default id to block menu template.

### DIFF
--- a/templates/block/block--system-menu-block.html.twig
+++ b/templates/block/block--system-menu-block.html.twig
@@ -40,7 +40,7 @@
     'menu--' ~ derivative_plugin_id|clean_class,
   ]
 %}
-{% set heading_id = attributes.id ~ '-menu'|clean_id %}
+{% set heading_id = attributes.id|default('block-' ~ base_plugin_id ~ '-' ~ derivative_plugin_id) ~ '-menu'|clean_id %}
 <nav role="navigation" aria-labelledby="{{ heading_id }}"{{ attributes.addClass(classes)|without('role', 'aria-labelledby') }}>
   {# Label. If not displayed, we still provide it for screen readers. #}
   {{ title_prefix }}


### PR DESCRIPTION
This can be tested on https://hershey.psul.localhost/ (need to clear cache).  There should be no blocks with id of `-menu`