### PR TITLE
276 improve buttons

### DIFF
--- a/components/button/button.example.html
+++ b/components/button/button.example.html
@@ -18,6 +18,7 @@
         <a href="#" class="btn btn-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-primary btn-sm">Button Text</a>
         <a href="#" class="btn btn-primary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-primary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-secondary">Button Text</a>
@@ -28,6 +29,7 @@
         <a href="#" class="btn btn-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-secondary btn-sm">Button Text</a>
         <a href="#" class="btn btn-secondary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-light">Button Text</a>
@@ -38,6 +40,7 @@
         <a href="#" class="btn btn-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-light btn-sm">Button Text</a>
         <a href="#" class="btn btn-light btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-light btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-primary">Button Text</a>
@@ -48,6 +51,7 @@
         <a href="#" class="btn btn-outline-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-primary btn-sm">Button Text</a>
         <a href="#" class="btn btn-outline-primary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-secondary">Button Text</a>
@@ -58,6 +62,7 @@
         <a href="#" class="btn btn-outline-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-secondary btn-sm">Button Text</a>
         <a href="#" class="btn btn-outline-secondary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-light">Button Text</a>
@@ -68,6 +73,7 @@
         <a href="#" class="btn btn-outline-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-light btn-sm">Button Text</a>
         <a href="#" class="btn btn-outline-light btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-report">Button Text</a>
       </p>
     </div>
 
@@ -81,6 +87,7 @@
         <a href="#" class="btn btn-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-primary btn-sm">Button Text</a>
         <a href="#" class="btn btn-primary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-primary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-secondary">Button Text</a>
@@ -91,6 +98,7 @@
         <a href="#" class="btn btn-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-secondary btn-sm">Button Text</a>
         <a href="#" class="btn btn-secondary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-light">Button Text</a>
@@ -101,6 +109,7 @@
         <a href="#" class="btn btn-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-light btn-sm">Button Text</a>
         <a href="#" class="btn btn-light btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-light btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-primary">Button Text</a>
@@ -111,6 +120,7 @@
         <a href="#" class="btn btn-outline-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-primary btn-sm">Button Text</a>
         <a href="#" class="btn btn-outline-primary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-secondary">Button Text</a>
@@ -121,6 +131,7 @@
         <a href="#" class="btn btn-outline-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-secondary btn-sm">Button Text</a>
         <a href="#" class="btn btn-outline-secondary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-light">Button Text</a>
@@ -131,6 +142,7 @@
         <a href="#" class="btn btn-outline-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-light btn-sm">Button Text</a>
         <a href="#" class="btn btn-outline-light btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-report">Button Text</a>
     </div>
 
     <div class="full-bleed full-bleed--slate-light">
@@ -143,6 +155,7 @@
         <a href="#" class="btn btn-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-primary btn-sm">Button Text</a>
         <a href="#" class="btn btn-primary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-primary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-secondary">Button Text</a>
@@ -153,6 +166,7 @@
         <a href="#" class="btn btn-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-secondary btn-sm">Button Text</a>
         <a href="#" class="btn btn-secondary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-light">Button Text</a>
@@ -163,6 +177,7 @@
         <a href="#" class="btn btn-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-light btn-sm">Button Text</a>
         <a href="#" class="btn btn-light btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-light btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-primary">Button Text</a>
@@ -173,6 +188,7 @@
         <a href="#" class="btn btn-outline-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-primary btn-sm">Button Text</a>
         <a href="#" class="btn btn-outline-primary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-secondary">Button Text</a>
@@ -183,6 +199,7 @@
         <a href="#" class="btn btn-outline-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-secondary btn-sm">Button Text</a>
         <a href="#" class="btn btn-outline-secondary btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-report">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-light">Button Text</a>
@@ -193,6 +210,7 @@
         <a href="#" class="btn btn-outline-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-light btn-sm">Button Text</a>
         <a href="#" class="btn btn-outline-light btn-navlink">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-report">Button Text</a>
     </div>
   </body>
 </html>

--- a/components/button/button.example.html
+++ b/components/button/button.example.html
@@ -1,0 +1,179 @@
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Button Examples</title>
+    <link rel="stylesheet" href="../../dist/css/style.css">
+    <link rel="stylesheet" href="button.css">
+  </head>
+  <body class="">
+    <h1>Buttons Examples</h1>
+    <div class="full-bleed full-bleed--navy">
+      <p>
+        <a href="#" class="btn btn-primary">Button Text</a>
+        <a href="#" class="btn btn-primary btn-round">Button Text</a>
+        <a href="#" class="btn btn-primary btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-primary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-primary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-secondary">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-round">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-secondary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-light">Button Text</a>
+        <a href="#" class="btn btn-light btn-round">Button Text</a>
+        <a href="#" class="btn btn-light btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-light btn-lg">Button Text</a>
+        <a href="#" class="btn btn-light btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-primary">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-round">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-primary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-secondary">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-square">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-round">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-secondary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-light">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-round">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-light btn-lg">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-sm">Button Text</a>
+      </p>
+    </div>
+    <div class="full-bleed full-bleed--limestone-light">
+      <p>
+        <a href="#" class="btn btn-primary">Button Text</a>
+        <a href="#" class="btn btn-primary btn-round">Button Text</a>
+        <a href="#" class="btn btn-primary btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-primary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-primary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-secondary">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-round">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-secondary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-light">Button Text</a>
+        <a href="#" class="btn btn-light btn-round">Button Text</a>
+        <a href="#" class="btn btn-light btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-light btn-lg">Button Text</a>
+        <a href="#" class="btn btn-light btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-primary">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-round">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-primary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-secondary">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-square">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-round">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-secondary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-light">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-round">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-light btn-lg">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-sm">Button Text</a>
+      </p>
+    </div>
+    <div class="full-bleed full-bleed--slate-light">
+      <p>
+        <a href="#" class="btn btn-primary">Button Text</a>
+        <a href="#" class="btn btn-primary btn-round">Button Text</a>
+        <a href="#" class="btn btn-primary btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-primary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-primary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-secondary">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-round">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-secondary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-light">Button Text</a>
+        <a href="#" class="btn btn-light btn-round">Button Text</a>
+        <a href="#" class="btn btn-light btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-light btn-lg">Button Text</a>
+        <a href="#" class="btn btn-light btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-primary">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-round">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-primary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-secondary">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-square">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-round">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-secondary btn-lg">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-sm">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-light">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-round">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-square">Button Text</a>
+      </p>
+      <p>
+        <a href="#" class="btn btn-outline-light btn-lg">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-sm">Button Text</a>
+      </p>
+    </div>  </body>
+</html>

--- a/components/button/button.example.html
+++ b/components/button/button.example.html
@@ -17,6 +17,7 @@
       <p>
         <a href="#" class="btn btn-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-primary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-primary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-secondary">Button Text</a>
@@ -26,6 +27,7 @@
       <p>
         <a href="#" class="btn btn-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-secondary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-light">Button Text</a>
@@ -35,6 +37,7 @@
       <p>
         <a href="#" class="btn btn-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-light btn-sm">Button Text</a>
+        <a href="#" class="btn btn-light btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-primary">Button Text</a>
@@ -44,6 +47,7 @@
       <p>
         <a href="#" class="btn btn-outline-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-primary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-secondary">Button Text</a>
@@ -53,6 +57,7 @@
       <p>
         <a href="#" class="btn btn-outline-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-secondary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-light">Button Text</a>
@@ -62,8 +67,10 @@
       <p>
         <a href="#" class="btn btn-outline-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-light btn-sm">Button Text</a>
+        <a href="#" class="btn btn-outline-light btn-navlink">Button Text</a>
       </p>
     </div>
+
     <div class="full-bleed full-bleed--limestone-light">
       <p>
         <a href="#" class="btn btn-primary">Button Text</a>
@@ -73,6 +80,7 @@
       <p>
         <a href="#" class="btn btn-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-primary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-primary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-secondary">Button Text</a>
@@ -82,6 +90,7 @@
       <p>
         <a href="#" class="btn btn-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-secondary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-light">Button Text</a>
@@ -91,6 +100,7 @@
       <p>
         <a href="#" class="btn btn-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-light btn-sm">Button Text</a>
+        <a href="#" class="btn btn-light btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-primary">Button Text</a>
@@ -100,6 +110,7 @@
       <p>
         <a href="#" class="btn btn-outline-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-primary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-secondary">Button Text</a>
@@ -109,6 +120,7 @@
       <p>
         <a href="#" class="btn btn-outline-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-secondary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-light">Button Text</a>
@@ -118,8 +130,9 @@
       <p>
         <a href="#" class="btn btn-outline-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-light btn-sm">Button Text</a>
-      </p>
+        <a href="#" class="btn btn-outline-light btn-navlink">Button Text</a>
     </div>
+
     <div class="full-bleed full-bleed--slate-light">
       <p>
         <a href="#" class="btn btn-primary">Button Text</a>
@@ -129,6 +142,7 @@
       <p>
         <a href="#" class="btn btn-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-primary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-primary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-secondary">Button Text</a>
@@ -138,6 +152,7 @@
       <p>
         <a href="#" class="btn btn-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-secondary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-secondary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-light">Button Text</a>
@@ -147,6 +162,7 @@
       <p>
         <a href="#" class="btn btn-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-light btn-sm">Button Text</a>
+        <a href="#" class="btn btn-light btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-primary">Button Text</a>
@@ -156,6 +172,7 @@
       <p>
         <a href="#" class="btn btn-outline-primary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-primary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-outline-primary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-secondary">Button Text</a>
@@ -165,6 +182,7 @@
       <p>
         <a href="#" class="btn btn-outline-secondary btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-secondary btn-sm">Button Text</a>
+        <a href="#" class="btn btn-outline-secondary btn-navlink">Button Text</a>
       </p>
       <p>
         <a href="#" class="btn btn-outline-light">Button Text</a>
@@ -174,6 +192,7 @@
       <p>
         <a href="#" class="btn btn-outline-light btn-lg">Button Text</a>
         <a href="#" class="btn btn-outline-light btn-sm">Button Text</a>
-      </p>
-    </div>  </body>
+        <a href="#" class="btn btn-outline-light btn-navlink">Button Text</a>
+    </div>
+  </body>
 </html>

--- a/components/button/button.scss
+++ b/components/button/button.scss
@@ -1,58 +1,32 @@
-// Generate styles for pagination.
+// Generate styles for buttons.
 @import '../../scss/init';
 
 // Override variables here.
-$btn-rounded-radius: .3rem !default;
+$btn-rounded-radius: .3rem;
+$btn-border-radius: 4px;
 
+// Button Variables.
 .btn {
+  --#{$prefix}border-radius: 4px;
   --#{$prefix}btn-rounded-radius: #{$btn-rounded-radius};
 }
+
+// Overriding the theme-colors here so we only create btn variants for
+// some of the theme colors.
+$theme-colors: (
+  "success":    $success,
+  "danger":     $danger,
+  "dark":       $dark
+);
 
 // Import bootstrap button styles and mixins.
 @import '~bootstrap/scss/mixins/_buttons.scss';
 @import '~bootstrap/scss/buttons';
 
-// Custom styles go here.
-button {
-  &.link {
-    @extend .btn;
-    @extend .btn-link;
-    color: $link-color;
-  }
-}
 
-.button {
-    @extend .btn;
-}
-
-.button--small {
-  @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $btn-font-size-sm, $btn-border-radius-sm);
-}
-
-a {
-  &.button {
-    @extend .btn;
-    text-decoration: none;
-
-    &.button--primary {
-      @include button-variant($primary, $primary);
-    }
-
-    &.button--danger {
-      @include button-variant($danger, $danger);
-    }
-
-    &.button-action {
-      @include button-variant($info, $info);
-    }
-
-    &.button--small {
-      @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $btn-font-size-sm, $btn-border-radius-sm);
-    }
-  }
-}
-
-// @todo - all div a should be updated in b5 theme for drupal
+// Loop through a subset of the theme colors and create button classes.
+// We only need a handful for backwards compatibility.  The rest are
+// based on the PSU Flex CTA buttons.
 @each $color, $value in $theme-colors {
   .btn-#{$color} {
     a {
@@ -83,12 +57,110 @@ a {
   }
 }
 
+// PSU Flex CTA Primary Outlined Button.
+.btn-primary {
+  @include button-variant(
+    $pa-link,
+    $pa-link,
+    $white,
+    $nittany-navy,
+    $nittany-navy,
+  );
+}
+
+// PSU Flex CTA Primary Filled Button
+.btn-outline-primary {
+  @include button-outline-variant(
+    $pa-link,
+  );
+}
+
+// PSU Flex CTA Light Outlined Button.
+.btn-secondary {
+  @include button-variant(
+    $pa-link-light,
+    $pa-link-light,
+    $nittany-navy,
+    $white,
+    $white,
+  );
+}
+
+.btn-outline-secondary {
+  @include button-outline-variant(
+    $pa-link-light,
+  );
+}
+
+.btn-light {
+  @include button-variant(
+    $white,
+    $white,
+    $nittany-navy,
+    $pa-link-light,
+    $pa-link-light,
+  );
+}
+
+.btn-outline-light {
+  @include button-outline-variant(
+    $white,
+  );
+}
+
+// Custom styles go here.
+button {
+  &.link {
+    @extend .btn;
+    @extend .btn-link;
+    color: $link-color;
+  }
+}
+
 // Add rounded color variant.
 .btn-rounded {
   @include border-radius(var(--#{$prefix}btn-rounded-radius));
 }
 
+.btn-square {
+  @include border-radius(0px);
+}
+
+.btn-round {
+  @include border-radius(100px);
+}
+
 // Override: '@classy/css/components/button.css'
+.button {
+    @extend .btn;
+}
+
+.button--small {
+  @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $btn-font-size-sm, $btn-border-radius-sm);
+}
+
+a {
+  &.button {
+    @extend .btn;
+    text-decoration: none;
+
+    &.button--primary {
+      @include button-variant($primary, $primary);
+    }
+
+    &.button--danger {
+      @include button-variant($danger, $danger);
+    }
+
+    &.button-action {
+      @include button-variant($info, $info);
+    }
+
+    &.button--small {
+      @include button-size($btn-padding-y-sm, $btn-padding-x-sm, $btn-font-size-sm, $btn-border-radius-sm);
+    }
+  }
+}
 
 .btn,
 .button {

--- a/components/button/button.scss
+++ b/components/button/button.scss
@@ -7,7 +7,7 @@ $btn-border-radius: 4px;
 
 // Button Variables.
 .btn {
-  --#{$prefix}border-radius: 4px;
+  --#{$prefix}border-radius: #{$btn-border-radius};
   --#{$prefix}btn-rounded-radius: #{$btn-rounded-radius};
 }
 
@@ -16,7 +16,8 @@ $btn-border-radius: 4px;
 $theme-colors: (
   "success":    $success,
   "danger":     $danger,
-  "dark":       $dark
+  "dark":       $dark,
+  "info":       $info,
 );
 
 // Import bootstrap button styles and mixins.
@@ -57,7 +58,10 @@ $theme-colors: (
   }
 }
 
-// PSU Flex CTA Primary Outlined Button.
+// Adding styles for the PSU Flex CTA buttons.
+// @see https://www.figma.com/design/QUWCtZma6OvgSVhnwobLZ0/Styles?node-id=1916-1265&t=175oGkjuPKqcLmh3-0
+
+// PSU Flex CTA Primary Filled Button.
 .btn-primary {
   @include button-variant(
     $pa-link,
@@ -68,14 +72,14 @@ $theme-colors: (
   );
 }
 
-// PSU Flex CTA Primary Filled Button
+// PSU Flex CTA Primary Outlined Button
 .btn-outline-primary {
   @include button-outline-variant(
     $pa-link,
   );
 }
 
-// PSU Flex CTA Light Outlined Button.
+// PSU Flex CTA Light Filled Button.
 .btn-secondary {
   @include button-variant(
     $pa-link-light,
@@ -86,12 +90,14 @@ $theme-colors: (
   );
 }
 
+// PSU Flex CTA Light Outlined Button
 .btn-outline-secondary {
   @include button-outline-variant(
     $pa-link-light,
   );
 }
 
+// PSU Flex CTA White Filled Button
 .btn-light {
   @include button-variant(
     $white,
@@ -102,10 +108,26 @@ $theme-colors: (
   );
 }
 
+// PSU Flex CTA White Outlined Button
 .btn-outline-light {
   @include button-outline-variant(
     $white,
   );
+}
+
+// Add class for navlink buttons.
+.btn-navlink {
+  @include border-radius(100px);
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+// Add variant for a full width button. This will take up the entire
+// space of the parent container.
+.btn-wide {
+  width: 100%;
 }
 
 // Custom styles go here.
@@ -117,15 +139,17 @@ button {
   }
 }
 
-// Add rounded color variant.
+// Add rounded variant (default).
 .btn-rounded {
   @include border-radius(var(--#{$prefix}btn-rounded-radius));
 }
 
+// Add square (no border-radius) variant.
 .btn-square {
   @include border-radius(0px);
 }
 
+// Add round variant.
 .btn-round {
   @include border-radius(100px);
 }

--- a/components/button/button.scss
+++ b/components/button/button.scss
@@ -124,6 +124,17 @@ $theme-colors: (
   padding-right: 1rem;
 }
 
+.btn-report {
+  --#{$prefix}btn-padding-x: 1.75rem;
+  --#{$prefix}btn-padding-y: 0.25rem;
+  --#{$prefix}btn-font-size: 1rem;
+  @include border-radius(0px);
+
+  line-height: 1;
+  font-family: $font-family-condensed;
+  text-transform: uppercase;
+}
+
 // Add variant for a full width button. This will take up the entire
 // space of the parent container.
 .btn-wide {

--- a/components/header/header.scss
+++ b/components/header/header.scss
@@ -111,16 +111,22 @@ header {
   ul[data-block="nav_additional"] {
     text-transform: uppercase;
 
-    // Most styles are .btn-navlink.  The remaining styles are to override
-    // the bootstrap navbar styles.
-    a.btn.button.btn-primary.btn-nav-additional {
-      font-size: 1rem;
+    // @todo make this an actual button variant.
+    a.btn.button.btn-primary.btn-nav-additional.nav-link {
+      font-size: 15.75px;
+      border-radius: 30px;
+      border-color: $psu-light-blue;
       margin: 7px 10px;
+      padding: 0 20px;
       text-transform: none;
       font-family: $font-family-sans-serif;
+      font-weight: 400;
 
       &:hover {
         text-decoration: none;
+        border-color: $navy-blue;
+        background-color: $navy-blue;
+        color: white;
       }
     }
   }

--- a/components/header/header.scss
+++ b/components/header/header.scss
@@ -111,22 +111,24 @@ header {
   ul[data-block="nav_additional"] {
     text-transform: uppercase;
 
-    // @todo make this an actual button variant.
+    // There is a btn-navlink button variant but we cannot use it because the
+    // bootstrap navbar styles are overriding it.
     a.btn.button.btn-primary.btn-nav-additional.nav-link {
-      font-size: 15.75px;
+      font-size: 1rem;
       border-radius: 30px;
-      border-color: $psu-light-blue;
+      border-color: $pa-link-light;
       margin: 7px 10px;
       padding: 0 20px;
       text-transform: none;
       font-family: $font-family-sans-serif;
       font-weight: 400;
+      color: $pa-link-light;
 
       &:hover {
         text-decoration: none;
-        border-color: $navy-blue;
-        background-color: $navy-blue;
-        color: white;
+        border-color: $pa-link-light;
+        background-color: $pa-link-light;
+        color: $nittany-navy;
       }
     }
   }

--- a/components/header/header.scss
+++ b/components/header/header.scss
@@ -111,22 +111,16 @@ header {
   ul[data-block="nav_additional"] {
     text-transform: uppercase;
 
-    // @todo make this an actual button variant.
-    a.btn.button.btn-primary.btn-nav-additional.nav-link {
-      font-size: 15.75px;
-      border-radius: 30px;
-      border-color: $psu-light-blue;
+    // Most styles are .btn-navlink.  The remaining styles are to override
+    // the bootstrap navbar styles.
+    a.btn.button.btn-primary.btn-nav-additional {
+      font-size: 1rem;
       margin: 7px 10px;
-      padding: 0 20px;
       text-transform: none;
       font-family: $font-family-sans-serif;
-      font-weight: 400;
 
       &:hover {
         text-decoration: none;
-        border-color: $navy-blue;
-        background-color: $navy-blue;
-        color: white;
       }
     }
   }

--- a/components/header_mark/header_mark.twig
+++ b/components/header_mark/header_mark.twig
@@ -10,10 +10,9 @@
 {% set logo_path = logo_path ?? path('<front>') %}
 
 <div {{ attributes.addClass(classes) }}>
-
   {% if site_logo %}
-  <a href="{{ logo_path }}" title="{{ logo_title|default('Home')|t }}" rel="home" class="site-logo d-block">
-    <img src="{{ site_logo }}" alt="{{ logo_title|default('Home')|t }}" fetchpriority="high" height="60" width="228" />
+  <a href="{{ logo_path }}" title="{{ logo_title|default("Home") }}" rel="home" class="site-logo d-block">
+    <img src="{{ site_logo }}" alt="{{ logo_title|default("Home") }}" fetchpriority="high" height="60" width="228" />
   </a>
   {% endif %}
   {% if site_name %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3540,9 +3540,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001707",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+      "version": "1.0.30001713",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
+      "integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3540,9 +3540,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001713",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
-      "integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
+      "version": "1.0.30001714",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz",
+      "integrity": "sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg==",
       "dev": true,
       "funding": [
         {

--- a/scss/_variables_bootstrap.scss
+++ b/scss/_variables_bootstrap.scss
@@ -34,3 +34,8 @@ $link-hover-color-dark: $pa-link-light !default;
 
 // Increasing navbar padding-y to add more space on mobile.
 $navbar-brand-padding-y: .75rem;
+
+// Increased x padding for buttons.
+$btn-padding-x: 1.5rem !default;
+$btn-padding-x-sm: 1.125rem !default;
+$btn-padding-x-lg: 2.5rem !default;


### PR DESCRIPTION
This is sort of a biggie.  I tried to sync the PSU Flex and Bootstrap button styles.  

## Changes
- Buttons should have a small radius by default now.
- The primary button style should be pa-link color
- There are new styles for making `Report` and `Navlink` buttons

## Testing Instructions
- Copy html content from button.example.html file into a new node.  You should see button styles similar to those in [Figma Button Styles](https://www.figma.com/design/QUWCtZma6OvgSVhnwobLZ0/Styles?node-id=3261-1185&t=175oGkjuPKqcLmh3-0)
- Spot check sites for impacts.
  - The PSUL Homepage search and header search blocks will need to be updated 

<img width="883" alt="Screenshot 2025-04-16 at 1 55 16 PM" src="https://github.com/user-attachments/assets/41e08fe6-99ad-40b7-9cd5-b102da8fee00" />
<img width="860" alt="Screenshot 2025-04-16 at 1 55 23 PM" src="https://github.com/user-attachments/assets/8257115b-28e2-4fda-ab64-7b184e8ee98e" />
