### PR TITLE
283 component divider

### DIFF
--- a/components/divider/divider.component.yml
+++ b/components/divider/divider.component.yml
@@ -1,0 +1,46 @@
+'$schema': 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: Divider
+status: stable
+description: Divider component.
+props:
+  type: 'object'
+  properties:
+    color:
+      type: 'string'
+      title: Color
+      description: Color of the divider
+      default: navy
+      enum:
+        - white
+        - navy
+        - pugh
+    width:
+      type: 'string'
+      title: Width
+      description: Width of the divider
+      default: sm
+      enum:
+        - full
+        - xs
+        - sm
+        - md
+        - lg
+        - xl
+    thickness:
+      type: 'string'
+      title: Thickness
+      description: Thickness of the divider
+      default: md
+      enum:
+        - xs
+        - sm
+        - md
+        - lg
+    orientation:
+      type: 'string'
+      title: Orientation
+      description: Orientation of the divider
+      default: horizontal
+      enum:
+        - horizontal
+        - vertical

--- a/components/divider/divider.scss
+++ b/components/divider/divider.scss
@@ -10,6 +10,7 @@
   border-top-width: 0px;
   border-right-width: 0px;
   border-left-width: 0px;
+  margin-top: $spacer * 0.75;
   margin-bottom: $spacer * 1.25;
 }
 

--- a/components/divider/divider.scss
+++ b/components/divider/divider.scss
@@ -1,0 +1,58 @@
+@import '../../scss/init';
+
+.divider {
+  --divider-color: #{$nittany-navy};
+  --divider-thickness: 2px;
+  --divider-width: 80px;
+
+  width: var(--divider-width);
+  border-bottom: var(--divider-thickness) solid var(--divider-color);
+  border-top-width: 0px;
+  border-right-width: 0px;
+  border-left-width: 0px;
+  margin-bottom: $spacer * 1.25;
+}
+
+// @todo - Add support for vertical dividers.  This is currently not working.
+.divider--orientation-vertical {
+  height: auto;
+  width: auto;
+  border-bottom-width: 0px;
+}
+
+$colors: (
+  "navy": #{$nittany-navy},
+  "pugh": #{$pugh-blue},
+  "white": #{$white}
+);
+@each $name, $color in $colors {
+  .divider--color-#{$name} {
+    --divider-color: #{$color};
+  }
+}
+
+$divider-width: (
+  "xs": 16px,
+  "sm": 32px,
+  "md": 48px,
+  "lg": 64px,
+  "xl": 80px,
+  'full': 100%,
+);
+@each $name, $width in $divider-width {
+  .divider--width-#{$name} {
+    --divider-width: #{$width};
+  }
+}
+
+$divider-thickness: (
+  "xs": 1px,
+  "sm": 2px,
+  "md": 3px,
+  "lg": 4px,
+);
+@each $name, $thickness in $divider-thickness {
+  .divider--thickness-#{$name} {
+    --divider-thickness: #{$thickness};
+  }
+}

--- a/components/divider/divider.twig
+++ b/components/divider/divider.twig
@@ -1,0 +1,11 @@
+{%
+  set classes = [
+    'divider',
+    'divider--orientation-' ~ orientation|default('horizontal'),
+    'divider--width-' ~ width|default('xs'),
+    'divider--color-' ~ color|default('navy'),
+    'divider--thickness-' ~ thickness|default('xs'),
+  ]|join(' ')
+%}
+
+<div class="{{ classes }}"></div>

--- a/components/heading/heading.component.yml
+++ b/components/heading/heading.component.yml
@@ -61,6 +61,19 @@ props:
       type: 'string'
       title: Content
       description: Content text for the heading.
+    divider:
+      type: 'boolean'
+      title: Divider
+      description: Add a divider below the heading.
+    divider_color:
+      type: 'string'
+      title: Divider Color
+      description: Color of the divider.
+      default: pugh
+      enum:
+        - white
+        - navy
+        - pugh
 slots:
   heading_content:
     title: Content

--- a/components/heading/heading.component.yml
+++ b/components/heading/heading.component.yml
@@ -62,18 +62,19 @@ props:
       title: Content
       description: Content text for the heading.
     divider:
-      type: 'boolean'
+      type: ['object', 'boolean']
       title: Divider
       description: Add a divider below the heading.
-    divider_color:
-      type: 'string'
-      title: Divider Color
-      description: Color of the divider.
-      default: pugh
-      enum:
-        - white
-        - navy
-        - pugh
+      properties:
+        color:
+          type: ['string']
+          title: Divider Color
+        thickness:
+          type: ['string']
+          title: Divider Thickness
+        width:
+          type: ['string']
+          title: Divider Width
 slots:
   heading_content:
     title: Content

--- a/components/heading/heading.twig
+++ b/components/heading/heading.twig
@@ -45,9 +45,9 @@
 {% endif %}
 {% if divider %}
   {% include 'psulib_base:divider' with {
-    width: 'xl',
-    thickness: 'md',
-    color: divider_color|default('navy'),
+    width: divider.width|default('xl'),
+    thickness: divider.thickness|default('md'),
+    color: divider.color|default('pugh'),
   } only %}
 {% endif %}
 {% endapply %}

--- a/components/heading/heading.twig
+++ b/components/heading/heading.twig
@@ -43,4 +43,11 @@
     {% endblock %}
   </{{heading_html_tag}}>
 {% endif %}
+{% if divider %}
+  {% include 'psulib_base:divider' with {
+    width: 'xl',
+    thickness: 'md',
+    color: divider_color|default('navy'),
+  } only %}
+{% endif %}
 {% endapply %}

--- a/components/not_found/not_found.scss
+++ b/components/not_found/not_found.scss
@@ -21,19 +21,8 @@
     }
   }
 
-  &--divider {
-    display: flex;
-    justify-content: flex-start;
-  }
-
-  &--divider-bar {
-    margin-top: $spacer;
-    margin-bottom: $spacer * 1.25;
-    width: $spacer * 5;
-    border-bottom: 4px solid $pugh-blue;
-    border-top-width: 4px;
-    border-right-width: 4px;
-    border-left-width: 4px;
+  .divider {
+    margin-top: $spacer * 1.75;
   }
 
   &--subtitle {

--- a/components/not_found/not_found.twig
+++ b/components/not_found/not_found.twig
@@ -11,13 +11,14 @@
     include 'psulib_base:heading' with {
       heading_html_tag: 'h1',
       content: title|default("Oops! We can't find that"),
-      heading_utility_classes: ['not-found--title']
+      heading_utility_classes: ['not-found--title'],
+      divider: {
+        color: 'pugh',
+        thickness: 'lg',
+        width: 'xl',
+      },
     }
   %}
-
-  <div class="not-found--divider">
-    <div class="not-found--divider-bar"></div>
-  </div>
 
   {%
     include 'psulib_base:heading' with {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3540,9 +3540,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001707",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+      "version": "1.0.30001713",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
+      "integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Adding a divider component.  This is currently only being used on the 404 and 403 pages but you can use those to play around with component. 

<img width="761" alt="Screenshot 2025-04-17 at 9 26 14 AM" src="https://github.com/user-attachments/assets/2b41295e-391d-4388-a5f0-a46a378c6471" />

## Testing Instructions
- Go to https://psul-web.psul.localhost/thisisnotapagelolololol
- You should see divider bar is displayed below the H1.
- You can tweak the settings in `web/themes/custom/psulib_base/components/not_found/not_found.twig` to see how this work. The available props are in the divider component.