### PR TITLE
292-remove underline from ckeditor_bs_accordion button

### DIFF
--- a/components/accordion/accordion.scss
+++ b/components/accordion/accordion.scss
@@ -54,5 +54,9 @@
         background-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2216%22%20height%3D%2216%22%20fill%3D%22%23001e44%22%20class%3D%22bi%20bi-plus%22%20viewBox%3D%220%200%2016%2016%22%3E%3Cpath%20d%3D%22M8%204a.5.5%200%200%201%20.5.5v3h3a.5.5%200%200%201%200%201h-3v3a.5.5%200%200%201-1%200v-3h-3a.5.5%200%200%201%200-1h3v-3A.5.5%200%200%201%208%204%22%2F%3E%3C%2Fsvg%3E ");
       }
     }
+
+    a.accordion-button {
+      text-decoration: none;
+    }
   }
 }


### PR DESCRIPTION
## To test

add an accordion via ckeditor. the accordion header items should not have underlines.