### PR TITLE
282 component image text overlap

### DIFF
--- a/components/divider/divider.component.yml
+++ b/components/divider/divider.component.yml
@@ -14,6 +14,7 @@ props:
         - white
         - navy
         - pugh
+        - sky
     width:
       type: 'string'
       title: Width

--- a/components/divider/divider.scss
+++ b/components/divider/divider.scss
@@ -24,7 +24,8 @@
 $colors: (
   "navy": #{$nittany-navy},
   "pugh": #{$pugh-blue},
-  "white": #{$white}
+  "white": #{$white},
+  "sky": #{$pa-sky},
 );
 @each $name, $color in $colors {
   .divider--color-#{$name} {

--- a/components/image_text_overlap/README.md
+++ b/components/image_text_overlap/README.md
@@ -1,0 +1,38 @@
+# Image + Text Overlap
+
+## Examples
+
+### With Image URL String
+
+```twig
+<div class="full-bleed full-bleed--limestone-light">
+{%
+  include 'psulib_base:image_text_overlap' with {
+    image_src: 'https://images.ctfassets.net/ni9rh5nu0d99/7aVwroYXl3CQkyfQwEK1bG/999f75fe46e3cbbd2bea829866abe21a/traditions-lion-shrine.jpg?fm=webp&w=640&q=75',
+    title: 'Celebrating Pride and Connection',
+    body: {'#markup': '<p>We are proud to be a part of the Penn State community and to support our <a href="#">students, faculty, and staff</a> in their academic pursuits. We are committed to creating an inclusive environment that celebrates diversity and fosters connection.</p><p>Learn about the beginnings and legendary symbols of some of Penn State’s traditions.</p>'},
+    cta: {
+      title: 'Learn More',
+      url: '/about/traditions',
+    },
+  }
+%}
+</div>
+```
+
+### With media
+```twig
+<div class="full-bleed full-bleed--limestone-light">
+{%
+  include 'psulib_base:image_text_overlap' with {
+    image_media: image,
+    title: 'Celebrating Pride and Connection',
+    body: {'#markup': '<p>We are proud to be a part of the Penn State community and to support our <a href="#">students, faculty, and staff</a> in their academic pursuits. We are committed to creating an inclusive environment that celebrates diversity and fosters connection.</p><p>Learn about the beginnings and legendary symbols of some of Penn State’s traditions.</p>'},
+    cta: {
+      title: 'Learn More',
+      url: '/about/traditions',
+    },
+  }
+%}
+</div>
+```

--- a/components/image_text_overlap/image_text_overlap.component.yml
+++ b/components/image_text_overlap/image_text_overlap.component.yml
@@ -1,0 +1,42 @@
+'$schema': 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: "Image + Text Overlap"
+status: stable
+description: A component that displays an image and text in an overlapping manner.
+props:
+  type: 'object'
+  properties:
+    text_position:
+      type: 'string'
+      title: Text Position
+      description: The position of the text relative to the image.
+      default: right
+      enum:
+        - left
+        - right
+    title:
+      type: 'string'
+      title: Title
+    subtitle:
+      type: 'string'
+      title: Subtitle
+    body:
+      type: 'string'
+      title: Body
+    cta_button:
+      type: 'object'
+      title: CTA Button
+      properties:
+        title:
+          type: 'string'
+          title: Button Title
+        url:
+          type: 'string'
+          title: Button URL
+    image_media:
+      type: 'string'
+      title: Image Media
+    image_src:
+      type: 'string'
+      title: Image Source URL
+    attributes:
+      type: 'Drupal\Core\Template\Attribute'

--- a/components/image_text_overlap/image_text_overlap.scss
+++ b/components/image_text_overlap/image_text_overlap.scss
@@ -1,0 +1,109 @@
+@import '../../scss/init';
+
+.image-text-overlap {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: $spacer * 0.75;
+  margin: ($spacer * 3) 0;
+
+  @include media-breakpoint-up(md) {
+    grid-template-columns: repeat(8, 1fr);
+    gap: $spacer * 1;
+  }
+
+  @include media-breakpoint-up(lg) {
+    grid-template-columns: repeat(12, 1fr);
+    gap: $spacer * 1.25;
+  }
+
+  @include media-breakpoint-up(xl) {
+    gap: $spacer * 1.75;
+  }
+
+  &__image-wrapper {
+    grid-column: 1/span 4;
+    grid-row: 1/span 8;
+    z-index: 3;
+
+    @include media-breakpoint-up(md) {
+      grid-column: 2/span 6;
+      grid-row: 1/span 8;
+    }
+
+    @include media-breakpoint-up(lg) {
+      grid-column: 1/span 10;
+      grid-row: 1/span 1;
+      z-index: 2;
+    }
+
+    @include media-breakpoint-up(xl) {
+      grid-column: 1/span 9;
+      grid-row: 1/span 2;
+    }
+
+    img {
+      max-width: 100%;
+      height: auto;
+      vertical-align: bottom;
+      border-radius: $border-radius-lg !important;
+      aspect-ratio: 3/2;
+    }
+  }
+
+  &__text {
+    background-color: $nittany-navy;
+    color: $white;
+    z-index: 2;
+    grid-column: 1/span 4;
+    grid-row: 8/span 9;
+    padding: ($spacer * 5) 1.5rem ($spacer * 2.5) 1.5rem;
+    margin: 0 (-1.5rem);
+
+    @include make-link($white, 'underline', $white, 'none');
+
+    @include media-breakpoint-up(md) {
+      grid-column: 1/span 8;
+      grid-row: 8/span 9;
+      padding: ($spacer * 5) ($spacer * 3.75) ($spacer * 3.75) ($spacer * 3.75);
+    }
+
+    @include media-breakpoint-up(lg) {
+      margin: 2.5rem 0 0 0;
+      grid-column: 9/span 9;
+      grid-row: 1/span 1;
+      padding: $spacer * 2.5;
+      z-index: 3;
+    }
+
+    @include media-breakpoint-up(xl) {
+      padding: $spacer * 3.75;
+      margin-top: 3.75rem;
+      grid-column: 9/span 9;
+      grid-row: 1/span 1;
+    }
+
+    &-body {
+      p:last-child {
+        margin-bottom: 0;
+      }
+    }
+
+    a.btn {
+      margin: ($spacer * 1.5) 0 0 0;
+    }
+  }
+
+  &__title,
+  &__subtitle {
+    color: $white;
+    font-size: $spacer * 1.375;
+
+    @include media-breakpoint-up(md) {
+      font-size: $spacer * 1.5;
+    }
+
+    @include media-breakpoint-up(lg) {
+      font-size: $spacer * 1.75;
+    }
+  }
+}

--- a/components/image_text_overlap/image_text_overlap.twig
+++ b/components/image_text_overlap/image_text_overlap.twig
@@ -1,0 +1,49 @@
+{%
+  set classes = [
+    'image-text-overlap',
+    'image-text-overlap--text-' ~ text_position,
+  ]
+%}
+
+{% set attributes = attributes ?: create_attribute() %}
+
+<div {{ attributes.addClass(classes) }}>
+  <div class="image-text-overlap__image-wrapper">
+    {% if image_src %}
+      <img alt="{{ img_alt }}" loading="lazy" width="900" height="600" decoding="async" class="image-text-overlap__image" src="{{ image_src }}" />
+    {% else %}
+      {{ image_media }}
+    {% endif %}
+  </div>
+  <div class="image-text-overlap__text">
+    <div class="image-text-overlap__text-inner">
+      {% if subtitle %}
+        <div class="h3 text-uppercase image-text-overlap__subtitle">{{subtitle}}</div>
+      {% endif %}
+
+      {% if title %}
+        {%
+          include 'psulib_base:heading' with {
+            heading_html_tag: 'h2',
+            content: title,
+            divider: {
+              color: 'sky',
+              width: 'xl',
+            },
+            heading_utility_classes: ['image-text-overlap__title'],
+          }
+        %}
+      {% endif %}
+
+      {% if body %}
+        <div class="image-text-overlap__text-body">
+          {{ body }}
+        </div>
+      {% endif %}
+
+      {% if cta %}
+        <a class="btn btn-outline-light" href="{{ cta.url }}">{{ cta.title }} <i class="bi bi-chevron-right"></i></a>
+      {% endif %}
+    </div>
+  </div>
+</div>

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -5,7 +5,7 @@
   $a-link-hover-color: $link-hover-color,
   $a-link-hover-decoration: $link-decoration,
   $target-class: '') {
-  a#{$target-class} {
+  a#{$target-class}:not(.btn) {
     color: $a-link-color;
     text-decoration: $a-link-decoration;
 

--- a/scss/base/_full_bleed.scss
+++ b/scss/base/_full_bleed.scss
@@ -5,7 +5,7 @@
   box-shadow: 0 0 0 100vmax var(--full-bleed-bg-color);
   clip-path: inset(0 -100vmax);
   background-color: var(--full-bleed-bg-color);
-  padding: $spacer;
+  padding: $spacer 0;
 }
 
 .full-bleed--slate-light {


### PR DESCRIPTION
Adding a new component.

<img width="1502" alt="Screenshot 2025-04-17 at 3 20 44 PM" src="https://github.com/user-attachments/assets/21c91909-cf04-4169-a8be-cecadd59a08a" />

## Testing Instructions
You can add the following to a twig template (could be `page.html.twig` or `page--front.html.twig`).  This should behave like the Image + Text Overlap component on the psu.edu homepage.

```twig
<div class="full-bleed full-bleed--limestone-light">
{%
  include 'psulib_base:image_text_overlap' with {
    image_src: 'https://images.ctfassets.net/ni9rh5nu0d99/7aVwroYXl3CQkyfQwEK1bG/999f75fe46e3cbbd2bea829866abe21a/traditions-lion-shrine.jpg?fm=webp&w=640&q=75',
    title: 'Celebrating Pride and Connection',
    body: {'#markup': '<p>We are proud to be a part of the Penn State community and to support our <a href="#">students, faculty, and staff</a> in their academic pursuits. We are committed to creating an inclusive environment that celebrates diversity and fosters connection.</p><p>Learn about the beginnings and legendary symbols of some of Penn State’s traditions.</p>'},
    cta: {
      title: 'Learn More',
      url: '/about/traditions',
    },
  }
%}
</div>
```
