### PR TITLE
325 add template for landing page

### DIFF
--- a/layouts/psul-one-column.html.twig
+++ b/layouts/psul-one-column.html.twig
@@ -1,11 +1,9 @@
 {% if content %}
   <div {{ attributes.addClass('psul-one-column') }}>
-    <div class="row mb-4">
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>
         {{ content.main }}
       </div>
     {% endif %}
-    </div>
   </div>
 {% endif %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5233,9 +5233,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001724",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001724.tgz",
-      "integrity": "sha512-WqJo7p0TbHDOythNTqYujmaJTvtYRZrjpP8TCvH6Vb9CYJerJNKamKzIWOM4BkQatWj9H2lYulpdAQNBe7QhNA==",
+      "version": "1.0.30001726",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
+      "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
       "dev": true,
       "funding": [
         {

--- a/psulib_base.theme
+++ b/psulib_base.theme
@@ -6,6 +6,7 @@
  */
 
 use Drupal\block\Entity\Block;
+use Drupal\node\NodeInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
 
@@ -192,6 +193,23 @@ function psulib_base_preprocess_block(&$variables) {
         $variables['content']['#attributes']['data-block']['region'] = $region;
       }
     }
+  }
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for page.
+ *
+ * Add layout builder suggestions for pages that use Layout Builder.
+ */
+function psulib_base_theme_suggestions_page_alter(array &$suggestions, array $variables) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+
+  if (isset($node) && $node instanceof NodeInterface) {
+    if ($node->hasField('layout_builder__layout') && $node->layout_builder__layout->getValue()) {
+      $suggestions[] = 'page__node__lb_display';
+      $suggestions[] = 'page__node__' . $node->bundle() . '__lb_display';
+    }
+    $suggestions[] = 'page__node__' . $node->bundle();
   }
 }
 

--- a/scss/base/_layout.scss
+++ b/scss/base/_layout.scss
@@ -60,3 +60,15 @@
     flex-basis: 300px;
   }
 }
+
+.lb-display {
+  .region-content {
+    margin-bottom: 0;
+  }
+
+  // Sections in layout builder have a top and bottom padding of 3rem.
+  .node__content > div {
+    padding-top: $spacer * 1.5;
+    padding-bottom: $spacer * 1.5;
+  }
+}

--- a/scss/base/_typography.scss
+++ b/scss/base/_typography.scss
@@ -39,3 +39,7 @@ h1, .h1 {
 h2, .h2 {
   margin-bottom: $spacer;
 }
+
+p:last-child {
+  margin-bottom: 0;
+}

--- a/templates/layout/page--node--lb-display.html.twig
+++ b/templates/layout/page--node--lb-display.html.twig
@@ -1,0 +1,98 @@
+{#
+/**
+ * @file
+ * Theme override to display a single page.
+ *
+ * The doctype, html, head and body tags are not in this template. Instead they
+ * can be found in the html.html.twig template in this directory.
+ *
+ * Available variables:
+ *
+ * General utility variables:
+ * - base_path: The base URL path of the Drupal installation. Will usually be
+ *   "/" unless you have installed Drupal in a sub-directory.
+ * - is_front: A flag indicating if the current page is the front page.
+ * - logged_in: A flag indicating if the user is registered and signed in.
+ * - is_admin: A flag indicating if the user has permission to access
+ *   administration pages.
+ *
+ * Site identity:
+ * - front_page: The URL of the front page. Use this instead of base_path when
+ *   linking to the front page. This includes the language domain or prefix.
+ *
+ * Page content (in order of occurrence in the default page.html.twig):
+ * - node: Fully loaded node, if there is an automatically-loaded node
+ *   associated with the page and the node ID is the second argument in the
+ *   page's path (e.g. node/12345 and node/12345/revisions, but not
+ *   comment/reply/12345).
+ *
+ * Regions:
+ * - page.above_header: Announcements and alerts, etc.
+ * - page.header: Items for the header region.
+ * - page.primary_menu: Items for the primary menu region.
+ * - page.secondary_menu: Items for the secondary menu region.
+ * - page.highlighted: Items for the highlighted content region.
+ * - page.help: Dynamic help text, mostly for admin pages.
+ * - page.content: The main content of the current page.
+ * - page.sidebar_first: Items for the first sidebar.
+ * - page.sidebar_second: Items for the second sidebar.
+ * - page.footer: Items for the footer region.
+ * - page.breadcrumb: Items for the breadcrumb region.
+ *
+ * @see template_preprocess_page()
+ * @see html.html.twig
+ */
+#}
+{%
+set footer_classes = 'text-light'
+%}
+
+{# Add the header component from psulib_base theme. #}
+{% include 'psulib_base:header' with {
+    above_header: page.above_header,
+    header: page.header,
+    nav_branding: page.nav_branding,
+    nav_main: page.nav_main,
+    nav_additional: page.nav_additional,
+    show_navbar_menus: page.nav_main or page.nav_additional,
+    nav_offcanvas: page.nav_offcanvas,
+    nav_search: page.nav_search,
+    nav_offcanvas: page.nav_offcanvas,
+    nav_actions: page.nav_actions,
+  }
+%}
+
+<main role="main" class="lb-display">
+  <a id="main-content" tabindex="-1"></a>{# link is in html.html.twig #}
+
+  <div class="container-fluid mt-4">
+    {% if page.breadcrumb %}
+      {{ page.breadcrumb }}
+    {% endif %}
+    <div class="region-content-wrapper {{ content_classes }}">
+      {{ page.content }}
+    </div>
+  </div>
+
+</main>
+
+{# Add the footer component from psulib_base theme. #}
+{% embed 'psulib_base:footer' with {
+    show_footer_left: page.footer_left is not empty,
+    show_footer_right: page.footer is not empty,
+    show_footer_bottom: page.footer_bottom is not empty,
+    site_logo: site_logo,
+    site_logo_alt: 'Home'|t,
+    site_logo_url: path('<front>')
+  }
+%}
+  {% block footer_left %}
+    {{ page.footer_left }}
+  {% endblock %}
+  {% block footer_right %}
+    {{ page.footer }}
+  {% endblock %}
+  {% block footer_bottom %}
+    {{ page.footer_bottom }}
+  {% endblock %}
+{% endembed %}


### PR DESCRIPTION
This requires layout builder to work.  I can checkout https://github.com/psu-libraries/psul-web/pull/911 in psul-web

## Changes
- Adds template for nodes using layout builder (and theme suggestions so this can be overridden)
- Adjust styles to make spacing more consistent around sections and layout pages.

## Testing Instructions
- Create a Landing page
- Update the layout (Add sections and text blocks).
- Spacing should be consistent.