### PR TITLE
Issue #327 - Adding block around the items array so Drupal can overri…

### DIFF
--- a/components/card_grid/card_grid.component.yml
+++ b/components/card_grid/card_grid.component.yml
@@ -88,4 +88,10 @@ props:
       examples:
         title: 'Learn More'
         url: '#'
-
+slots:
+  cards:
+    title: Cards
+    description: The cards go here.
+    type: ['string', 'object']
+    examples:
+      - '<div class="card">Card content goes here.</div><div class="card">Card content goes here.</div><div class="card">Card content goes here.</div>'

--- a/components/card_grid/card_grid.twig
+++ b/components/card_grid/card_grid.twig
@@ -34,16 +34,18 @@
 
   {# Cards #}
   <div class="card-grid__cards">
-    {% for item in items %}
-      {% set item = item|merge({
-        card_utility_classes: card_utility_classes,
-        card_link_stretched: card_link_stretched|default(false),
-        card_title_tag: card_title_tag ?? 'h3',
-      }) %}
+    {% block cards %}
+      {% for item in items %}
+        {% set item = item|merge({
+          card_utility_classes: card_utility_classes,
+          card_link_stretched: card_link_stretched|default(false),
+          card_title_tag: card_title_tag ?? 'h3',
+        }) %}
 
-      {# Merge default values with the item #}
-      {% include 'psulib_base:card' with item %}
-    {% endfor %}
+        {# Merge default values with the item #}
+        {% include 'psulib_base:card' with item %}
+      {% endfor %}
+    {% endblock %}
   </div>
 
   {% if cta_button %}


### PR DESCRIPTION
…de the cards.

Storybook's twig.js does not handle block overrides so this needs to be tested in Drupal.  You can add the following to any template (e.g. 404) and cards will be displayed.

```twig
    <div class="full-bleed full-bleed--limestone-light">
    {%
      embed 'psulib_base:card_grid' with {
        card_link_stretched: true,
        card_columns: 3,
        card_type: 'cta',
        card_title_tag: 'h2'
      }
    %}
      {% block cards %}
        <div class="card">
          <div class="card-body">
            <h2 class="card-title">Access Denied</h2>
            <p class="card-text">You do not have permission to access this page.</p>
            <p class="card-text">If you believe this is an error, please contact the</p>
          </div>
        </div>
        <div class="card">
          <div class="card-body">
            <h2 class="card-title">Access Denied</h2>
            <p class="card-text">You do not have permission to access this page.</p>
            <p class="card-text">If you believe this is an error, please contact the</p>
          </div>
        </div>
        <div class="card">
          <div class="card-body">
            <h2 class="card-title">Access Denied</h2>
            <p class="card-text">You do not have permission to access this page.</p>
            <p class="card-text">If you believe this is an error, please contact the</p>
          </div>
        </div>
      {% endblock %}
    {% endembed %}
    </div>
```