### PR TITLE
339 add library search component

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -26,6 +26,7 @@ import './storybook.css';
 
 // Import all js.
 import '../js/psul-bootstrap.js';
+import '../js/base/jumpmenu.js';
 
 export const decorators = [
   withThemeByDataAttribute({

--- a/components/library_search/library_search.component.yml
+++ b/components/library_search/library_search.component.yml
@@ -1,0 +1,52 @@
+'$schema': 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: Library Search
+status: stable
+description: Search Control for the Library search and home pages.
+props:
+  type: 'object'
+  properties:
+    title:
+      type: 'string'
+      title: Title
+      description: Title to display.
+      examples:
+        - 'What can we help you find?'
+    placeholder:
+      type: 'string'
+      title: Placeholder Text
+      description: Text to display in the search input when empty.
+      examples:
+        - 'Search the catalog, articles, and more...'
+    action:
+      type: 'string'
+      title: Form Action
+      description: Action to perform on form submission.
+      examples:
+        - 'https://libraries.psu.edu/search/all'
+    links:
+      type: 'array'
+      title: Links
+      description: List of links to display below the search form.
+      items:
+        type: 'object'
+        properties:
+          text:
+            type: 'string'
+            title: Link Text
+            description: Text to display for the link.
+          url:
+            type: 'string'
+            title: Link URL
+            description: URL to link to.
+          attributes:
+            title: Druapl Attributes
+      examples:
+        -
+          - text: 'Search Catalog'
+            url: '#'
+          - text: 'Search Databases'
+            url: '#'
+          - text: 'Search eJournals'
+            url: '#'
+          - text: 'Course Reserves'
+            url: '#'

--- a/components/library_search/library_search.component.yml
+++ b/components/library_search/library_search.component.yml
@@ -50,3 +50,8 @@ props:
             url: '#'
           - text: 'Course Reserves'
             url: '#'
+slots:
+  form:
+    title: Form Slot
+    description: Replace the entire form with a custom form component.
+    type: ['object', 'string']

--- a/components/library_search/library_search.scss
+++ b/components/library_search/library_search.scss
@@ -26,7 +26,7 @@
 .library-search__form {
   display: flex;
   flex-direction: column;
-  gap: $spacer * 1.5;
+  gap: $spacer * 1;
 
   .library-search__input-wrapper {
     flex-grow: 1;
@@ -34,6 +34,7 @@
 
   @include media-breakpoint-up(sm) {
     flex-direction: row;
+    gap: $spacer * 1.5;
   }
 
 }
@@ -48,11 +49,38 @@
 
 .library-search__link {
   @include make-link($link-color, none, $link-hover-color, underline);
+  &.list-inline-item {
+    display: list-item;
+
+    @include media-breakpoint-up(sm) {
+      display: inline-block;
+    }
+  }
   &:not(:last-child) {
-    margin-right: 0;
+    margin-right: $spacer;
   }
 
-  &:not(:first-child) {
-    margin-left: $spacer;
+  .psul-icon {
+
+    svg {
+      vertical-align: middle;
+      height: .875rem;
+      width: .875rem;
+    }
+  }
+}
+
+.library-search__jump-menu {
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: $spacer * 1.5;
+  .btn-lg {
+    --bs-btn-font-size: #{$font-size-sm};
+    --bs-btn-padding-x: 1.5rem;
+    --bs-btn-padding-y: 0.375rem;
+    border-radius: var(--bs-border-radius);
+  }
+  .psul-icon {
+    display: none;
   }
 }

--- a/components/library_search/library_search.scss
+++ b/components/library_search/library_search.scss
@@ -1,0 +1,58 @@
+@import '../../scss/init';
+
+.library-search {
+  --bs-border-width: 1px;
+  --bs-border-radius: 4px;
+  --bs-border-color: #{$body-color};
+  margin: ($spacer * 3) 0;
+
+  .input,
+  .btn {
+    --bs-btn-font-size: #{$font-size-base};
+    font-size: var(--bs-btn-font-size);
+    margin: 0;
+  }
+
+
+  @include media-breakpoint-up(md) {
+    .form-control,
+    .btn {
+      --bs-btn-font-size: #{$font-size-lg};
+      font-size: var(--bs-btn-font-size);
+    }
+  }
+}
+
+.library-search__form {
+  display: flex;
+  flex-direction: column;
+  gap: $spacer * 1.5;
+
+  .library-search__input-wrapper {
+    flex-grow: 1;
+  }
+
+  @include media-breakpoint-up(sm) {
+    flex-direction: row;
+  }
+
+}
+
+.library-search__links {
+  margin-top: $spacer;
+  font-size: $font-size-sm;
+  @include media-breakpoint-up(xl) {
+    margin-right: 145px;
+  }
+}
+
+.library-search__link {
+  @include make-link($link-color, none, $link-hover-color, underline);
+  &:not(:last-child) {
+    margin-right: 0;
+  }
+
+  &:not(:first-child) {
+    margin-left: $spacer;
+  }
+}

--- a/components/library_search/library_search.twig
+++ b/components/library_search/library_search.twig
@@ -5,16 +5,17 @@
       <h2 class="library-search__title">{{ title }}</h2>
     {% endif %}
 
-    <form class="library-search__form" action="{{ action }}" method="get">
-      <div class="library-search__input-wrapper">
-        <label for="library-search-input" class="visually-hidden">Search</label>
-        <input type="text" id="library-search-input" name="query" placeholder="{{ placeholder|default('Search for books, articles, and more...') }}" class="library-search__input form-control">
-      </div>
-      <button type="submit" class="library-search__button btn btn-primary">
-        Search
-      </button>
-
-    </form>
+    {% block form %}
+      <form class="library-search__form" action="{{ action }}" method="get">
+        <div class="library-search__input-wrapper">
+          <label for="library-search-input" class="visually-hidden">Search</label>
+          <input type="text" id="library-search-input" name="query" placeholder="{{ placeholder|default('Search for books, articles, and more...') }}" class="library-search__input form-control">
+        </div>
+        <button type="submit" class="library-search__button btn btn-primary">
+          Search
+        </button>
+      </form>
+    {% endblock %}
     {% if links %}
       <div class="d-flex justify-content-start justify-content-md-end">
         <ul class="library-search__links list-inline jump-menu" data-jump-id="library-search--links" data-jump-title="More Search Options" data-jump-breakpoint="sm" data-jump-classes="library-search__jump-menu">

--- a/components/library_search/library_search.twig
+++ b/components/library_search/library_search.twig
@@ -1,0 +1,29 @@
+<div class="row library-search">
+
+  <div class="col-12 col-lg-10 offset-lg-1">
+    {% if title %}
+      <h2 class="library-search__title">{{ title }}</h2>
+    {% endif %}
+
+    <form class="library-search__form" action="{{ action }}" method="get">
+      <div class="library-search__input-wrapper">
+        <label for="library-search-input" class="visually-hidden">Search</label>
+        <input type="text" id="library-search-input" name="query" placeholder="{{ placeholder|default('Search for books, articles, and more...') }}" class="library-search__input form-control">
+      </div>
+      <button type="submit" class="library-search__button btn btn-primary">
+        Search
+      </button>
+
+    </form>
+    {% if links %}
+      <ul class="library-search__links list-inline text-end">
+        {% for link in links %}
+          <li class="library-search__link list-inline-item">
+            <a href="{{ link.url }}">{{ link.text }} ></a>
+          </li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+  </div>
+
+</div>

--- a/components/library_search/library_search.twig
+++ b/components/library_search/library_search.twig
@@ -16,13 +16,16 @@
 
     </form>
     {% if links %}
-      <ul class="library-search__links list-inline text-end">
-        {% for link in links %}
-          <li class="library-search__link list-inline-item">
-            <a href="{{ link.url }}">{{ link.text }} ></a>
-          </li>
-        {% endfor %}
-      </ul>
+      <div class="d-flex justify-content-start justify-content-md-end">
+        <ul class="library-search__links list-inline jump-menu" data-jump-id="library-search--links" data-jump-title="More Search Options" data-jump-breakpoint="sm" data-jump-classes="library-search__jump-menu">
+
+          {% for link in links %}
+            <li class="library-search__link list-inline-item">
+              <a href="{{ link.url }}">{{ link.text }} {% include 'psulib_base:icon' with {icon: 'chevronRight', color: 'link'} %}</a>
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
     {% endif %}
   </div>
 

--- a/components/pagination/pagination.component.yml
+++ b/components/pagination/pagination.component.yml
@@ -40,7 +40,7 @@ props:
       type: 'Drupal\Core\Template\Attribute'
     items:
       title: Items with pages, first, previous, current, next, last
-      type: 'array'
+      type: ['array', 'null']
       default: []
       properties:
         first:

--- a/scss/base/_full_bleed.scss
+++ b/scss/base/_full_bleed.scss
@@ -1,11 +1,19 @@
 .full-bleed {
   // Setting this to transparent so it does nohthing unless a color is set.
   --full-bleed-bg-color: transparent;
-
-  box-shadow: 0 0 0 100vmax var(--full-bleed-bg-color);
-  clip-path: inset(0 -100vmax);
-  background-color: var(--full-bleed-bg-color);
+  position: relative;
   padding: $spacer 0;
+
+  &:after {
+    position: absolute;
+    z-index: -1;
+    height: 100%;
+    top: 0;
+    box-shadow: 0 0 0 100vmax var(--full-bleed-bg-color);
+    clip-path: inset(0 -100vmax);
+    background-color: var(--full-bleed-bg-color);
+    content: ' ';
+  }
 }
 
 .full-bleed--slate-light {

--- a/stories/psul-homepage.stories.js
+++ b/stories/psul-homepage.stories.js
@@ -4,8 +4,8 @@ import footer, {Libraries as LibrariesFooter} from '../components/footer/footer.
 import header, {Libraries as LibrariesHeader} from '../components/header/header.component.yml'
 import heading from '../components/heading/heading.component.yml'
 import imageTextOverlap from '../components/image_text_overlap/image_text_overlap.component.yml'
-// import newsCards from '../components/news_cards/news_cards.component.yml'
 import imageFile from '../.storybook/public/sample.jpg';
+import librarySearch from '../components/library_search/library_search.component.yml';
 import './page-preview.css'
 
 // Explicitly importing grandchild components css since this is not properly
@@ -19,25 +19,19 @@ export default {
     ${header.component({...LibrariesHeader.args})}
 
     <div class="container-fluid">
-      <div class="py-5 full-bleed full-bleed--slate-light">
-        ${heading.component({ content: 'What can we help you find?', heading_html_tag: 'h1', heading_utility_classes: ['h3']})}
-        <form class="row g-3">
-          <div class="col-auto">
-            <label for="search1" class="visually-hidden">Password</label>
-            <input type="text" class="form-control" size="100" id="search1" placeholder="Search for books, articles, and more...">
-          </div>
-          <div class="col-auto">
-            <button type="submit" class="btn btn-primary mb-3">Search</button>
-          </div>
-          <div class="text-end">
-            <ul class="list-inline">
-              <li class="list-inline-item"><a href="#" class="btn btn-sm btn-link">Search Catalog > </a></li>
-              <li class="list-inline-item"><a href="#" class="btn btn-sm btn-link">Search Databases > </a></li>
-              <li class="list-inline-item"><a href="#" class="btn btn-sm btn-link">Search eJournals > </a></li>
-              <li class="list-inline-item"><a href="#" class="btn btn-sm btn-link">Course Reserves > </a></li>
-            </ul>
-          </div>
-        </form>
+      <div class="py-3 full-bleed full-bleed--slate-light">
+        ${librarySearch.component({
+          title: 'What can we help you find?',
+          placeholder: 'Search the catalog, articles, and more...',
+          action: 'https://libraries.psu.edu/search/all',
+          links: [
+            { text: 'Search Catalog', url: '#' },
+            { text: 'Search Databases', url: '#' },
+            { text: 'Search eJournals', url: '#' },
+            { text: 'Course Reserves', url: '#' },
+          ],
+        })}
+
       </div>
       <div class="py-3">
         ${cardGrid.component({

--- a/stories/psul-homepage.stories.js
+++ b/stories/psul-homepage.stories.js
@@ -19,7 +19,7 @@ export default {
     ${header.component({...LibrariesHeader.args})}
 
     <div class="container-fluid">
-      <div class="py-3 full-bleed full-bleed--slate-light">
+      <div class="pt-4 pb-1 full-bleed full-bleed--slate-light">
         ${librarySearch.component({
           title: 'What can we help you find?',
           placeholder: 'Search the catalog, articles, and more...',


### PR DESCRIPTION
A mock up the desktop display of the library component can be found [in Figma](https://www.figma.com/design/BxEdRfr8AFa5bG0DYOVzcF/PSUL-Header-Mockups?node-id=864-249&t=9Sc4xwiygFCKh3BC-0).

<img width="884" alt="Screenshot 2025-07-02 at 9 49 39 AM" src="https://github.com/user-attachments/assets/c8f02b35-45ac-492c-bdf8-6f80351e88dd" />

## Testing Instructions
- Go to http://localhost:6006/?path=/story/sdc-library-search--basic
- You should the search form component form.  This should look ok on all screen sizes (any feedback is appreciated)
- Go to http://localhost:6006/?path=/story/psu-libraries-homepage--basic
- The full-bleed styles should look ok.
- You should the search form component form.  This should look ok on all screen sizes (any feedback is appreciated)
- Go to https://psul-web.psul.localhost/directory?search=&expertise=All&campus=beaver&library=All&department=All
- The full-bleed styles should look ok. The page should load (fixing #341)