### PR TITLE
Issue #343 - Adding link target prop to heading component.

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -19,6 +19,7 @@ import '../dist/css/nav.css';
 
 // Imports the CSS for common components.
 import '../components/button/button.css';
+import '../components/divider/divider.css';
 import '../components/icon/icon.css';
 
 // Imports all Storybook CSS for display.

--- a/components/heading/heading.component.yml
+++ b/components/heading/heading.component.yml
@@ -44,6 +44,17 @@ props:
       title: Utility Classes
       default: []
       description: An array of utility classes. Use to add extra Bootstrap utility classes or custom CSS classes over to this component.
+    heading_link_target:
+      type: ['string', 'null']
+      title: Heading Link Attributes
+      enum:
+        - ''
+        - '_blank'
+        - '_self'
+        - '_parent'
+        - '_top'
+      examples:
+        - '_blank'
     heading_link_utility_classes:
       type: 'array'
       items:

--- a/components/heading/heading.twig
+++ b/components/heading/heading.twig
@@ -34,7 +34,11 @@
   <{{heading_html_tag}} {{ heading_attributes.addClass(heading_classes).addClass(heading_utility_classes|default([])) }}>
     {% block heading_content %}
       {% if title_link %}
-        {% set heading_link_attributes = create_attribute() %}
+          {% set attrs = heading_link_target ? {
+            'target': heading_link_target,
+          } : {} %}
+        {% set heading_link_attributes = create_attribute(attrs)  %}
+
         <a {{ heading_link_attributes.setAttribute('href', title_link).addClass(heading_link_utility_classes|default([])) }}>
           {{ content }}
         </a>


### PR DESCRIPTION
Minor change.  This allow target attribute to be added to headings with links.

## Testing Instructions
- Go to http://localhost:6006/?path=/story/sdc-heading--basic
- Set title_link to "https://psu.edu"
- Set the heading_link_target to "_blank"
- View source.
- You should see the heading is a link with a target attribute of _blank.
- Changing the target value will be reflected in the story.