### PR TITLE
348 add 2 column layout that mirror standard node layout

### DIFF
--- a/layouts/psul-two-column.html.twig
+++ b/layouts/psul-two-column.html.twig
@@ -1,0 +1,35 @@
+{%
+  set main_class = [
+    'psul-layout-column--main',
+    'col-12',
+    content.sidebar ? 'col-lg' : 'col-12',
+  ]
+%}
+
+{%
+  set sidebar_classes = [
+    'psul-layout-column--sidebar',
+    'col-12',
+    content.main ? 'col-sm-6 col-lg col-lg-w350' : 'col-12',
+    'order-lg-first',
+  ]
+%}
+
+{% if content %}
+  <div {{ attributes.addClass('psul-two-column ') }}>
+    <div class="row gy-3 gy-lg-0 gx-lg-4 mb-3 mb-lg-4">
+    {% if content.main %}
+      <div {{ region_attributes.main.addClass(main_class) }}>
+        {{ content.main }}
+      </div>
+    {% endif %}
+    {% if content.sidebar %}
+      <div {{ region_attributes.sidebar.addClass(sidebar_classes) }}>
+        <div class="text-bg-light p-3">
+          {{ content.sidebar }}
+        </div>
+      </div>
+    {% endif %}
+    </div>
+  </div>
+{% endif %}

--- a/psulib_base.layouts.yml
+++ b/psulib_base.layouts.yml
@@ -1,5 +1,5 @@
 psulib_one_col:
-  label: 'PSUL One column'
+  label: 'One column'
   category: 'PSU Libraries'
   template: layouts/psul-one-column
   default_region: main
@@ -9,8 +9,21 @@ psulib_one_col:
   icon_map:
     - [main]
 
+psulib_two_col:
+  label: 'Two column - 350px sidebar'
+  category: 'PSU Libraries'
+  template: layouts/psul-two-column
+  default_region: main
+  regions:
+    main:
+      label: Main content
+    sidebar:
+      label: Sidebar
+  icon_map:
+    - [sidebar, main, main]
+
 psulib_two_col_33_66:
-  label: 'PSUL Two column 33/66'
+  label: 'Two column 33/66'
   category: 'PSU Libraries'
   template: layouts/psul-two-column-33-66
   default_region: main
@@ -23,7 +36,7 @@ psulib_two_col_33_66:
     - [sidebar, main, main]
 
 psulib_two_col_50_50:
-  label: 'PSUL Two column 50/50'
+  label: 'Two column 50/50'
   category: 'PSU Libraries'
   template: layouts/psul-two-column-50-50
   default_region: first
@@ -36,7 +49,7 @@ psulib_two_col_50_50:
     - [first, second]
 
 psulib_two_col_66_33:
-  label: 'PSUL Two column 66/33'
+  label: 'Two column 66/33'
   category: 'PSU Libraries'
   template: layouts/psul-two-column-66-33
   default_region: main

--- a/psulib_base.theme
+++ b/psulib_base.theme
@@ -245,6 +245,18 @@ function psulib_base_theme_suggestions_field_alter(array &$suggestions, array $v
 }
 
 /**
+ * Implements hook_plugin_filter_TYPE__CONSUMER_alter() for layout_builder.
+ *
+ * Remove default layouts from Layout Builder.
+ */
+function psulib_base_plugin_filter_layout__layout_builder_alter(array &$variables, array $extra) {
+  unset($variables['layout_onecol']);
+  unset($variables['layout_twocol_section']);
+  unset($variables['layout_threecol_section']);
+  unset($variables['layout_fourcol_section']);
+}
+
+/**
  * Implements theme_preprocess_image().
  */
 function psulib_base_preprocess_image(&$variables) {

--- a/templates/navigation/menu--main--nav-main.html.twig
+++ b/templates/navigation/menu--main--nav-main.html.twig
@@ -18,4 +18,7 @@
  *   - in_active_trail: TRUE if the link is in the active trail.
  */
 #}
-{% include 'psulib_base:sidebar_menu' %}
+{% include 'psulib_base:header_nav' with {
+  menu_name: menu_name,
+  items: items
+} %}


### PR DESCRIPTION
## Changes.

- Added new layout that mirrors page layout (with one column with gray background).  
- Added hook to remove default layouts
- Updated the main menu templates to use sidebar menu layout by default (instead of header menu).

<img width="1368" alt="Screenshot 2025-07-09 at 7 33 39 PM" src="https://github.com/user-attachments/assets/1138ba52-7a54-481a-bd65-e86261dd25b1" />

## Testing Instructions
- Checkout https://github.com/psu-libraries/psul-web/pull/937 on psul-web (and deploy changes)
- Clear cache
- Add or Edit a landing page layout
- Add section
- You should see 5 sections include the layout (default layout builder styles should not displayed only psulib_base layouts should be visible).
- Add "Two column 350px sidebar"
- Add menu block to the side bar of layout (see image below for settings)
- Add content to the main section of layout
- You should see a layout like that above 
<img width="606" alt="Screenshot 2025-07-09 at 7 59 56 PM" src="https://github.com/user-attachments/assets/f41a4339-575b-4f0b-8d6b-6cfc08a6c838" />
