### PR TITLE
Issue #356 - Fixing issues calendar and locationPin icons so the work…

### DIFF
--- a/components/event/event.twig
+++ b/components/event/event.twig
@@ -36,10 +36,9 @@
           <span class="event-card__time-text">{{ time }}</span>
         </div>
       {% endif %}
-
       {% if location %}
         <div class="event-card__location event-card__item">
-          {% include 'psulib_base:icon' with { icon: 'calendar' } %}
+          {% include 'psulib_base:icon' with { icon: 'locationPin' } %}
           <span class="visually-hidden">Location:</span>
           <span class="event-card__location-text">{{ location }}</span>
         </div>

--- a/components/icon/icon.component.yml
+++ b/components/icon/icon.component.yml
@@ -14,12 +14,14 @@ props:
       enum:
         - alarm
         - barChart3
+        - calendar
         - chevronRight
         - email
         - fax
         - help
         - institution
         - linkOut
+        - locationPin
         - openBook
         - person
         - phone


### PR DESCRIPTION
… with events.

## Testing Instructions
- Go to http://localhost:6006/?path=/story/sdc-card-grid--events
- Icons for date (calendar) time (clock) and location (locationPin) should look correct.

<img width="342" height="266" alt="Screenshot 2025-07-15 at 2 53 51 PM" src="https://github.com/user-attachments/assets/94186de0-3e1c-4384-b6b1-db680f5094be" />
