### PR TITLE
386 allow attributes to be passed to card component and heading component

### DIFF
--- a/components/card/card.component.yml
+++ b/components/card/card.component.yml
@@ -77,6 +77,9 @@ props:
       title: Card Link
       description: The URL to link to when the card is clicked.
       default: '#'
+    card_link_attributes:
+      type: 'Drupal\Core\Template\Attribute'
+      title: Card Link Attributes
     card_link_stretched:
       type: 'boolean'
       title: Stretched Link

--- a/components/card/card.twig
+++ b/components/card/card.twig
@@ -80,6 +80,7 @@
 {% set card_header_attributes = create_attribute() %}
 {% set card_footer_attributes = create_attribute() %}
 {% set card_subtitle_attributes = create_attribute() %}
+{% set card_link_attributes = card_link_attributes ?: create_attribute() %}
 {% set card_image_cap = card_image_cap|default('top') %}
 
 {%
@@ -150,6 +151,7 @@
             heading_attributes: card_title_attributes,
             heading_utility_classes: card_title_classes,
             title_link: card_link ?? false,
+            heading_link_attributes: card_link_attributes,
             heading_link_utility_classes: card_header_link_classes,
           }
         %}

--- a/components/heading/heading.component.yml
+++ b/components/heading/heading.component.yml
@@ -55,6 +55,9 @@ props:
         - '_top'
       examples:
         - '_blank'
+    heading_link_attributes:
+      type: 'Drupal\Core\Template\Attribute'
+      title: Heading Link Attributes
     heading_link_utility_classes:
       type: 'array'
       items:

--- a/components/heading/heading.twig
+++ b/components/heading/heading.twig
@@ -34,10 +34,10 @@
   <{{heading_html_tag}} {{ heading_attributes.addClass(heading_classes).addClass(heading_utility_classes|default([])) }}>
     {% block heading_content %}
       {% if title_link %}
-          {% set attrs = heading_link_target ? {
-            'target': heading_link_target,
-          } : {} %}
-        {% set heading_link_attributes = create_attribute(attrs)  %}
+        {% set attrs = heading_link_target ? {
+          'target': heading_link_target,
+        } : {} %}
+        {% set heading_link_attributes = heading_link_attributes ?: create_attribute() %}
 
         <a {{ heading_link_attributes.setAttribute('href', title_link).addClass(heading_link_utility_classes|default([])) }}>
           {{ content }}


### PR DESCRIPTION
## Testing Instructions
- Go to http://localhost:6006/?path=/story/sdc-card-grid--basic
- Click through each card
- They should load without issue.
- With `984-add-ability-to-convert-basic-pages-to-landing-pages` checked out in the psul-web project
- Add a card_grid with a nav card and an icon card 
- Set link target (new window)
- The link should be updated and open in a new window.