### PR TITLE
Issue #396 - Layout template: cleaned up, adding additional classes. …

### DIFF
--- a/components/card_grid/card_grid.scss
+++ b/components/card_grid/card_grid.scss
@@ -78,3 +78,8 @@
   }
 
 }
+
+// Remove margin-top if the card-grid is the first child on first region.
+.layout:not(.full-bleed):first-child .layout__region .block:first-child .card-grid {
+  margin-top: 0;
+}

--- a/layouts/psul-one-column.html.twig
+++ b/layouts/psul-one-column.html.twig
@@ -1,5 +1,14 @@
+{%
+  set main_class = [
+    'psul-layout-column--main',
+    'layout__region',
+    'col-12',
+    content.sidebar ? 'col-lg-8' : 'col-12',
+  ]
+%}
+
 {% if content %}
-  <div {{ attributes.addClass('psul-one-column') }}>
+  <div {{ attributes.addClass('layout psul-one-column') }}>
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>
         {{ content.main }}

--- a/layouts/psul-two-column-33-66.html.twig
+++ b/layouts/psul-two-column-33-66.html.twig
@@ -1,22 +1,24 @@
 {%
   set main_class = [
     'psul-layout-column--main',
+    'layout__region',
     'col-12',
-    content.sidebar ? 'col-lg-8' : 'col-12',
+    content.sidebar ? 'col-lg-8' : '',
   ]
 %}
 
 {%
   set sidebar_classes = [
     'psul-layout-column--sidebar',
+    'layout__region',
     'col-12',
-    content.main ? 'col-lg-4' : 'col-12',
+    content.main ? 'col-lg-4' : '',
     'order-lg-first',
   ]
 %}
 
 {% if content %}
-  <div {{ attributes.addClass('psul-two-column ') }}>
+  <div {{ attributes.addClass('layout psul-two-column ') }}>
     <div class="row gy-3 gy-lg-0 gx-lg-5 mb-3 mb-lg-4">
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>

--- a/layouts/psul-two-column-50-50.html.twig
+++ b/layouts/psul-two-column-50-50.html.twig
@@ -1,21 +1,23 @@
 {%
   set first_classes = [
     'psul-layout-column--first',
+    'layout__region',
     'col-12',
-    content.second ? 'col-lg-6' : 'col-12',
+    content.second ? 'col-lg-6' : '',
   ]
 %}
 
 {%
   set second_classes = [
     'psul-layout-column--second',
+    'layout__region',
     'col-12',
-    content.first ? 'col-lg-6' : 'col-12',
+    content.first ? 'col-lg-6' : '',
   ]
 %}
 
 {% if content %}
-  <div {{ attributes.addClass('psul-two-column') }}>
+  <div {{ attributes.addClass('layout psul-two-column') }}>
     <div class="row gy-3 gy-lg-0 gx-lg-5 mb-3 mb-lg-4">
     {% if content.first %}
       <div {{ region_attributes.first.addClass(first_classes) }}>

--- a/layouts/psul-two-column-66-33.html.twig
+++ b/layouts/psul-two-column-66-33.html.twig
@@ -1,21 +1,23 @@
 {%
   set main_class = [
     'psul-layout-column--main',
+    'layout__region',
     'col-12',
-    content.sidebar ? 'col-lg-8' : 'col-12',
+    content.sidebar ? 'col-lg-8' : '',
   ]
 %}
 
 {%
   set sidebar_classes = [
     'psul-layout-column--sidebar',
+    'layout__region',
     'col-12',
-    content.main ? 'col-lg-4' : 'col-12',
+    content.main ? 'col-lg-4' : '',
   ]
 %}
 
 {% if content %}
-  <div {{ attributes.addClass('psul-two-column') }}>
+  <div {{ attributes.addClass('layout psul-two-column') }}>
     <div class="row gy-3 gy-lg-0 gx-lg-5 mb-3 mb-lg-4">
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>

--- a/layouts/psul-two-column.html.twig
+++ b/layouts/psul-two-column.html.twig
@@ -1,6 +1,7 @@
 {%
   set main_class = [
     'psul-layout-column--main',
+    'layout__region',
     'col-12',
     'col-lg',
   ]
@@ -10,27 +11,16 @@
   set sidebar_classes = [
     'psul-layout-column--sidebar',
     'psul-layout-column--sidebar-gray',
+    'layout__region',
     'col-12',
     'col-sm-6 col-lg col-lg-w350',
     'order-lg-first',
   ]
 %}
-{# {{ dump(region_attributes.sidebar) }} #}
-{# {% set sidebar_attributes = region_attributes.sidebar|default(create_attribute()) %} #}
 
 {% if content %}
-  <div {{ attributes.addClass('psul-two-column ') }}>
+  <div {{ attributes.addClass('layout psul-two-column') }}>
     <div class="row gy-3 gy-lg-0 gx-lg-4 mb-3 mb-lg-4">
-    {# {% if content.main %}
-      <div {{ region_attributes.main.addClass(main_class) }}>
-        {{ content.main }}
-      </div>
-    {% endif %} #}
-    {# {% if content.sidebar %}
-      <div {{ region_attributes.sidebar.addClass(sidebar_classes) }}>
-        {{ content.sidebar }}
-      </div>
-    {% endif %} #}
 
     {% if content.main %}
       <div {{ region_attributes.main.addClass(main_class) }}>
@@ -39,12 +29,12 @@
         {% if content.bottom_left or content.bottom_right %}
           <div class="row gy-3 gy-lg-0 gx-lg-4 mt-3">
             {% if content.bottom_left %}
-              <div {{ region_attributes.bottom_left.addClass('col-12 col-lg') }}>
+              <div {{ region_attributes.bottom_left.addClass('col-12 col-lg layout__region psul-layout-column--bottom-left') }}>
                 {{ content.bottom_left }}
               </div>
             {% endif %}
             {% if content.bottom_right %}
-              <div {{ region_attributes.bottom_right.addClass('col-12 col-lg') }}>
+              <div {{ region_attributes.bottom_right.addClass('col-12 col-lg layout__region psul-layout-column--bottom-right') }}>
                 {{ content.bottom_right }}
               </div>
             {% endif %}
@@ -54,9 +44,7 @@
     {% endif %}
     {% if content.sidebar %}
       <div {{ region_attributes.sidebar.addClass(sidebar_classes) }}>
-        {# <div class="text-bg-light p-3"> #}
-          {{ content.sidebar }}
-        {# </div> #}
+        {{ content.sidebar }}
       </div>
     {% else %}
       <div class="{{sidebar_classes|join(' ') }}"></div>


### PR DESCRIPTION
… Adding style to remove top margin from card grids at the top of the first region.  

## Changes
- Layout template:
  - cleaned up template to remove the 
  - adding additional classes to the layouts
- Adding style to remove top margin from card grids at the top of the first region.

## Testing Instructions
- There should be no change to the homepage styles https://psul-web.psul.localhost/
- Go to https://psul-web.psul.localhost/about
- You should see the Spacing above and below the breadcrumbs are equal.

<img width="1354" height="650" alt="Screenshot 2025-08-19 at 9 58 13 AM" src="https://github.com/user-attachments/assets/ca2ecc0e-ddf5-4c95-851e-3246c7d6cf67" />
<img width="1291" height="627" alt="Screenshot 2025-08-19 at 9 58 36 AM" src="https://github.com/user-attachments/assets/c603c2d3-55bc-48b2-bea2-225f2980ba81" />
<img width="1341" height="735" alt="Screenshot 2025-08-19 at 9 58 42 AM" src="https://github.com/user-attachments/assets/3b81d5c8-d64f-4ec9-9647-b2061919c602" />
