### PR TITLE
Issue #380 - Adding margin-bottom to bootstrap grid divs added in the…

### DIFF
--- a/scss/base/_node.scss
+++ b/scss/base/_node.scss
@@ -19,3 +19,8 @@
     margin-right: calc(100% - 500px);
   }
 }
+
+// Adding margin to Bootstrap grid elements in WYSIWYG.
+.bs_grid:not(:last-child) {
+  margin-bottom: $spacer;
+}


### PR DESCRIPTION
… WYSIWYG editor.

## Testing Instructions
- Create a basic page with the following in the content:

The following illustrates the issue: 

```html
<p>
    Non dictumst congue pede tortor efficitur curabitur habitasse habitant. Dignissim malesuada felis penatibus mus risus a potenti feugiat platea leo. Pellentesque quis nullam morbi molestie magnis eros ultrices at class egestas consectetur. Himenaeos consequat phasellus convallis metus facilisis. Lectus ante penatibus non eleifend orci. Nostra platea amet mollis laoreet pretium.
</p>
<div class="bs_grid ck-widget" contenteditable="false">
    <div class="row ck-widget" data-row-none="none" data-row-sm="none" data-row-md="equal_equal" data-row-lg="none" data-row-xl="" data-row-xxl="" contenteditable="false">
        <div class="col-md">
            <p>
                Column 1 content
            </p>
        </div>
        <div class="col-md">
            <p>
                Column 2 content
            </p>
        </div>
    </div>
</div>
<p>
    Hendrerit ac vel a etiam nam sodales et. Condimentum nisl sollicitudin rhoncus eros vitae adipiscing sodales orci dictum neque. Tempus pulvinar fames si augue nunc. Feugiat mus nibh class dignissim enim.
</p>
<p>
    Fermentum leo dictum sit morbi lacinia. Feugiat ultricies pellentesque tortor taciti eleifend fermentum. Lectus ultricies pharetra nulla litora pellentesque tempus porttitor platea dictumst odio. Adipiscing sed praesent ex odio risus. Mauris senectus pretium nostra posuere vivamus. Nunc dapibus rhoncus penatibus ante fermentum.
</p>
```

- You should see 
- The is spacing between the bootstrap grid and the paragraph below. 