### PR TITLE
Issue #399 - Explicitly setting success and danger subtle bg colors.

### DIFF
--- a/scss/_colors.scss
+++ b/scss/_colors.scss
@@ -10,7 +10,6 @@ $off-off-white: darken($off-white, 10%); // used in collection panes
 $attn-yellow: #ebc100; // attention grabbing yellow
 $midnight-blue: #0a0f15; // high alert links color
 $valchar-blue: #2b76c7; // used on the background color of buttons on the homepage for Research Help and Tools
-$subtle-gray: #b5b5b5;
 $valchar-grey: #363636; // used on the homepage background for Research Help and Tools
 $valchar-light-grey: #f2f2f2; // used on the homepage background for Expert Help
 
@@ -102,6 +101,11 @@ $warning: $yellow !default;
 $danger: $red !default;
 $light: $pa-limestone-max-light !default;
 $dark: $pa-slate !default;
+
+// Subtle Colors
+$success-bg-subtle: #f2ffcc !default;
+$danger-bg-subtle: #f8d3de !default;
+$subtle-gray: #b5b5b5;
 
 $headings-color: $nittany-navy !default;
 $body-color: $old-coaly !default;


### PR DESCRIPTION
## Testing Instructions
- Start or Restart storybook
- Go to http://localhost:6006/?path=/story/sdc-alert-banner--basic
- The background colors should match the colors here: https://zeroheight.com/0e163bcc2/p/0600dd-alert-banners/b/469eaf/i/305204725 (based on the severity)
- Go to https://psul-web.psul.localhost/
- Add or enable a sitewide alert (High) 
- The background color should be the same for the wrapper and the alert.