### PR TITLE
Issue #395 - Copying print.css to peripheral directory to make it eas…

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -56,6 +56,7 @@ mix.copy([
 // Run build process for peripheral assets.
 mix.sass('scss/peripheral.scss', 'dist/peripheral').options(defaultSassOptions);
 mix.sass('scss/peripheral-bootstrap3.scss', 'dist/peripheral').options(defaultSassOptions);
+mix.copy('dist/css/print.css', 'dist/peripheral').options(defaultSassOptions);
 mix.js('js/psul-bootstrap.js', 'dist/peripheral/psul-bootstrap.js');
 mix.minify([
   'dist/peripheral/peripheral.css',


### PR DESCRIPTION
…ier to deploy to assets.

## Testing Instructions
- Run `ddev theme-build`
- In the psulib_base directory, run `ls -al ll dist/peripheral/`
- You should see a print.css file.