### PR TITLE
421-remove bg-light from webform details template

### DIFF
--- a/templates/form/details.html.twig
+++ b/templates/form/details.html.twig
@@ -21,7 +21,7 @@
       set summary_classes = [
         required ? 'js-form-required',
         required ? 'form-required invalid-feedback',
-        'card-header bg-light',
+        'card-header',
       ]
     %}
 


### PR DESCRIPTION
## To test

- add a Details field in webform with no custom classes. it should look correct.
- edit the field, go to `Summary attributes`. in `Summary CSS classes` field, enter `bg-info`. you should see the background color is changed to light blue